### PR TITLE
Graceful shutdown

### DIFF
--- a/yaqd_gage/_chopping.py
+++ b/yaqd_gage/_chopping.py
@@ -234,9 +234,8 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
     def set_edge_width_count(self, count: int) -> None:
         self._state["edge_width_count"] = count
 
-    def set_record_count(self, count: int) -> int:
+    def set_record_count(self, count: int) -> None:
         self._state["record_count"] = count
-        return count
 
-    def set_segment_count(self, count: int) -> int:
+    def set_segment_count(self, count: int) -> None:
         self._state["segment_count"] = count

--- a/yaqd_gage/_chopping.py
+++ b/yaqd_gage/_chopping.py
@@ -232,6 +232,7 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
         return out
 
     def set_edge_width_count(self, count: int) -> None:
+        assert count >= 0  # no limits_getter atm
         self._state["edge_width_count"] = count
 
     def set_record_count(self, count: int) -> None:

--- a/yaqd_gage/_chopping.py
+++ b/yaqd_gage/_chopping.py
@@ -10,7 +10,7 @@ import numpy as np  # type: ignore
 from yaqd_core import HasMeasureTrigger, IsSensor, IsDaemon
 
 from ._constants import acq_status_codes, transfer_modes
-from ._pygage import PyGage
+from ._pygage import PyGage, uses_pygage, async_uses_pygage
 
 
 impedences = {"fifty": 50, "onemeg": 1_000_000}
@@ -22,6 +22,26 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
     def __init__(self, name, config, config_filepath):
         super().__init__(name, config, config_filepath)
         self._pg = PyGage()
+        self._channel_names = []
+        self._max_segment_count = None  # redefined in _config_pygage
+        self._config_pygage()
+        self._channel_names.append("ai0")
+        self._channel_names.append("ai1")
+        self._channel_names.append("ai2")
+        self._channel_names.append("ai3")
+        self._channel_names.append("ai0_a")
+        self._channel_names.append("ai0_b")
+        self._channel_names.append("ai0_c")
+        self._channel_names.append("ai0_d")
+        self._channel_names.append("ai0_diff_abcd")
+        self._channel_names.append("ai0_diff_ab")
+        self._channel_names.append("ai0_diff_ad")
+        self._channel_units = {k: "V" for k in self._channel_names}
+        self._samples: Dict[str, np.ndarray] = dict()
+        self._segments: Dict[str, np.ndarray] = dict()
+
+    @uses_pygage
+    def _config_pygage(self):
         # acqusition config
         config = {}
         config["Mode"] = self._config["mode"]
@@ -35,6 +55,8 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
         config["ExtClk"] = int(self._config["ext_clk"])
         config["TimeStampMode"] = self._config["time_stamp_mode"]
         config["TimeStampClock"] = self._config["time_stamp_clock"]
+        # from state
+        config["SegmentCount"] = self._state["segment_count"]
         self._pg.set_acquisition_config(config)
         self._pg.set_multiple_rec_average_count(self._state["record_count"])
         # channel config
@@ -61,23 +83,7 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
             self._pg.set_trigger_config(trigger_index + 1, config)
         # finish
         self._pg.commit()
-        self._channel_names = []
-        self._channel_names.append("ai0")
-        self._channel_names.append("ai1")
-        self._channel_names.append("ai2")
-        self._channel_names.append("ai3")
-        self._channel_names.append("ai0_a")
-        self._channel_names.append("ai0_b")
-        self._channel_names.append("ai0_c")
-        self._channel_names.append("ai0_d")
-        self._channel_names.append("ai0_diff_abcd")
-        self._channel_names.append("ai0_diff_ab")
-        self._channel_names.append("ai0_diff_ad")
-        self._channel_units = {k: "V" for k in self._channel_names}
-        self._samples: Dict[str, np.ndarray] = dict()
-        self._segments: Dict[str, np.ndarray] = dict()
-        assert self._state["segment_count"] <= self.segment_count_limits[1]
-        self.set_segment_count(self._state["segment_count"])
+        self._max_segment_count = self._pg.max_segment_count
 
     def get_edge_width_count(self) -> int:
         return self._state["edge_width_count"]
@@ -95,22 +101,16 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
         return self._state["segment_count"]
 
     def get_segment_count_limits(self) -> List[int]:
-        return self.segment_count_limits
+        return [1, self._max_segment_count]
 
-    @property
-    def segment_count_limits(self):
-        return [1, self._pg.max_segment_count]
-
+    @async_uses_pygage
     async def _measure(self):
         out = dict()
-        assert self._state["segment_count"] <= self.segment_count_limits[1]
-        assert self._state["edge_width_count"] >= 0  # sanity
-        # set segment_count, record_count
-        segment_count = self._state["segment_count"]
-        record_count = self._state["record_count"]
-        self._pg.set_acquisition_config({"SegmentCount": segment_count})
-        self._pg.set_multiple_rec_average_count(record_count)
+        # apply state variables
+        self._pg.set_acquisition_config({"SegmentCount": self._state["segment_count"]})
+        self._pg.set_multiple_rec_average_count(self._state["record_count"])
         self._pg.commit()
+        self._max_segment_count = self._pg.max_segment_count
         # start capture
         self._pg.start_capture()
         # wait for capture to complete
@@ -122,6 +122,8 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
             await asyncio.sleep(0)
         # read out
         segments = {}
+        segment_count = self._state["segment_count"]
+        record_count = self._state["record_count"]
         for i in range(0, len(self._config["channels"])):
             s = await self._process_single_channel(i, segment_count, record_count)
             segments.update(s)
@@ -238,10 +240,3 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
 
     def set_segment_count(self, count: int) -> int:
         self._state["segment_count"] = count
-        return count
-
-    def close(self):
-        """close connection to gage board"""
-        if self._busy:
-            self._pg.abort_capture()
-        self._pg.free_system()

--- a/yaqd_gage/_chopping.py
+++ b/yaqd_gage/_chopping.py
@@ -76,8 +76,7 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
         self._channel_units = {k: "V" for k in self._channel_names}
         self._samples: Dict[str, np.ndarray] = dict()
         self._segments: Dict[str, np.ndarray] = dict()
-        self._segment_count_limits = [1, self._pg.max_segment_count]
-        assert self._state["segment_count"] <= self._segment_count_limits[1]
+        assert self._state["segment_count"] <= self.segment_count_limits[1]
         self.set_segment_count(self._state["segment_count"])
 
     def get_edge_width_count(self) -> int:
@@ -96,12 +95,15 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
         return self._state["segment_count"]
 
     def get_segment_count_limits(self) -> List[int]:
-        return self._segment_count_limits
+        return self.segment_count_limits
+
+    @property
+    def segment_count_limits(self):
+        return [1, self._pg.max_segment_count]
 
     async def _measure(self):
-        self._segment_count_limits = [1, self._pg.max_segment_count]
         out = dict()
-        assert self._state["segment_count"] <= self._segment_count_limits[1]
+        assert self._state["segment_count"] <= self.segment_count_limits[1]
         assert self._state["edge_width_count"] >= 0  # sanity
         # set segment_count, record_count
         segment_count = self._state["segment_count"]

--- a/yaqd_gage/_chopping.py
+++ b/yaqd_gage/_chopping.py
@@ -237,3 +237,9 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
     def set_segment_count(self, count: int) -> int:
         self._state["segment_count"] = count
         return count
+
+    def close(self):
+        """close connection to gage board"""
+        if self._busy:
+            self._pg.abort_capture()
+        self._pg.free_system()

--- a/yaqd_gage/_chopping.py
+++ b/yaqd_gage/_chopping.py
@@ -231,6 +231,9 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
 
         return out
 
+    def close(self):
+        self._pg.free_system()
+
     def set_edge_width_count(self, count: int) -> None:
         assert count >= 0  # no limits_getter atm
         self._state["edge_width_count"] = count

--- a/yaqd_gage/_compuscope.py
+++ b/yaqd_gage/_compuscope.py
@@ -10,7 +10,7 @@ import numpy as np  # type: ignore
 from yaqd_core import HasMeasureTrigger, IsSensor, IsDaemon
 
 from ._constants import acq_status_codes, transfer_modes
-from ._pygage import PyGage
+from ._pygage import PyGage, uses_pygage, async_uses_pygage
 
 
 impedences = {"fifty": 50, "onemeg": 1_000_000}
@@ -22,6 +22,20 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
     def __init__(self, name, config, config_filepath):
         super().__init__(name, config, config_filepath)
         self._pg = PyGage()
+        self._channel_names = []
+        self._max_segment_count = None  # redefined in _config_pygage
+        self._config_pygage()
+        for i in range(0, len(self._config["channels"])):
+            self._channel_names.append(f"channel{i+1}")
+            if self._config["channels"][i]["use_baseline"]:
+                self._channel_names.append(f"channel{i+1}_signal")
+                self._channel_names.append(f"channel{i+1}_baseline")
+        self._channel_units = {k: "V" for k in self._channel_names}
+        self._samples: Dict[str, np.ndarray] = dict()
+        self.set_segment_count(self._state["segment_count"])
+
+    @uses_pygage
+    def _config_pygage(self):
         # acqusition config
         config = {}
         config["Mode"] = self._config["mode"]
@@ -29,12 +43,13 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
         config["Depth"] = self._config["depth"]
         config["SegmentSize"] = self._config["segment_size"]
         config["TriggerDelay"] = self._config["trigger_delay"]
-        config["SegmentCount"] = self._state["segment_count"]
         config["TriggerTimeOut"] = self._config["trigger_time_out"]
         config["TriggerHoldOff"] = self._config["trigger_hold_off"]
         config["ExtClk"] = int(self._config["ext_clk"])
         config["TimeStampMode"] = self._config["time_stamp_mode"]
         config["TimeStampClock"] = self._config["time_stamp_clock"]
+        # from state
+        config["SegmentCount"] = self._state["segment_count"]
         self._pg.set_acquisition_config(config)
         self._pg.set_multiple_rec_average_count(self._config["record_count"])
         # channel config
@@ -61,16 +76,7 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
             self._pg.set_trigger_config(trigger_index + 1, config)
         # finish
         self._pg.commit()
-        self._channel_names = []
-        for i in range(0, len(self._config["channels"])):
-            self._channel_names.append(f"channel{i+1}")
-            if self._config["channels"][i]["use_baseline"]:
-                self._channel_names.append(f"channel{i+1}_signal")
-                self._channel_names.append(f"channel{i+1}_baseline")
-        self._channel_units = {k: "V" for k in self._channel_names}
-        self._samples: Dict[str, np.ndarray] = dict()
-        assert self._state["segment_count"] <= self.segment_count_limits[1]
-        self.set_segment_count(self._state["segment_count"])
+        self._max_segment_count = self._pg.max_segment_count
 
     def get_measured_samples(self):
         return self._samples
@@ -79,14 +85,11 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
         return self._state["segment_count"]
 
     def get_segment_count_limits(self) -> List[int]:
-        return self.segment_count_limits
+        return [1, self._max_segment_count]
 
-    @property
-    def segment_count_limits(self):
-        return [1, self._pg.max_segment_count]
-
+    @async_uses_pygage
     async def _measure(self):
-        assert self._state["segment_count"] <= self.segment_count_limits[1]
+        assert self._state["segment_count"] <= self._max_segment_count
         # start capture
         self._pg.start_capture()
         # wait for capture to complete
@@ -155,8 +158,3 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
         self._pg.commit()
         return count
 
-    def close(self):
-        """close connection to gage board"""
-        if self._busy:
-            self._pg.abort_capture()
-        self._pg.free_system()

--- a/yaqd_gage/_compuscope.py
+++ b/yaqd_gage/_compuscope.py
@@ -152,9 +152,8 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
             out[f"channel{channel_index+1}"] *= -1
         return out
 
-    def set_segment_count(self, count: int) -> int:
+    def set_segment_count(self, count: int) -> None:
         self._state["segment_count"] = count
         self._pg.set_acquisition_config({"SegmentCount": self._state["segment_count"]})
         self._pg.commit()
-        return count
 

--- a/yaqd_gage/_compuscope.py
+++ b/yaqd_gage/_compuscope.py
@@ -89,7 +89,9 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
 
     @async_uses_pygage
     async def _measure(self):
-        assert self._state["segment_count"] <= self._max_segment_count
+        # apply state
+        self._pg.set_acquisition_config({"SegmentCount": self._state["segment_count"]})
+        self._pg.commit()
         # start capture
         self._pg.start_capture()
         # wait for capture to complete
@@ -153,7 +155,5 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
         return out
 
     def set_segment_count(self, count: int) -> None:
+        assert count <= self._max_segment_count
         self._state["segment_count"] = count
-        self._pg.set_acquisition_config({"SegmentCount": self._state["segment_count"]})
-        self._pg.commit()
-

--- a/yaqd_gage/_compuscope.py
+++ b/yaqd_gage/_compuscope.py
@@ -156,4 +156,3 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
         self._state["segment_count"] = count
         self._pg.set_acquisition_config({"SegmentCount": self._state["segment_count"]})
         self._pg.commit()
-

--- a/yaqd_gage/_compuscope.py
+++ b/yaqd_gage/_compuscope.py
@@ -69,8 +69,7 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
                 self._channel_names.append(f"channel{i+1}_baseline")
         self._channel_units = {k: "V" for k in self._channel_names}
         self._samples: Dict[str, np.ndarray] = dict()
-        self._segment_count_limits = [1, self._pg.max_segment_count]
-        assert self._state["segment_count"] <= self._segment_count_limits[1]
+        assert self._state["segment_count"] <= self.segment_count_limits[1]
         self.set_segment_count(self._state["segment_count"])
 
     def get_measured_samples(self):
@@ -80,11 +79,14 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
         return self._state["segment_count"]
 
     def get_segment_count_limits(self) -> List[int]:
-        return self._segment_count_limits
+        return self.segment_count_limits
+
+    @property
+    def segment_count_limits(self):
+        return [1, self._pg.max_segment_count]
 
     async def _measure(self):
-        self._segment_count_limits = [1, self._pg.max_segment_count]
-        assert self._state["segment_count"] <= self._segment_count_limits[1]
+        assert self._state["segment_count"] <= self.segment_count_limits[1]
         # start capture
         self._pg.start_capture()
         # wait for capture to complete

--- a/yaqd_gage/_compuscope.py
+++ b/yaqd_gage/_compuscope.py
@@ -152,3 +152,9 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
         self._pg.set_acquisition_config({"SegmentCount": self._state["segment_count"]})
         self._pg.commit()
         return count
+
+    def close(self):
+        """close connection to gage board"""
+        if self._busy:
+            self._pg.abort_capture()
+        self._pg.free_system()

--- a/yaqd_gage/_compuscope.py
+++ b/yaqd_gage/_compuscope.py
@@ -96,12 +96,12 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
             if acq_status_codes[code] == "ACQ_STATUS_READY":
                 break
             await asyncio.sleep(0)
-        print("TIME WAITED", time.time() - before)
+        self.logger.debug("TIME WAITED", time.time() - before)
         # read out
         out = {}
         for i in range(0, len(self._config["channels"])):
             out.update(self._process_single_channel(i))
-        print(out)
+        self.logger.debug(out)
         return out
 
     def _process_single_channel(self, channel_index: int) -> Dict[str, float]:

--- a/yaqd_gage/_compuscope.py
+++ b/yaqd_gage/_compuscope.py
@@ -154,6 +154,9 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
             out[f"channel{channel_index+1}"] *= -1
         return out
 
+    def close(self):
+        self._pg.free_system()
+
     def set_segment_count(self, count: int) -> None:
         assert count <= self._max_segment_count
         self._state["segment_count"] = count

--- a/yaqd_gage/_pygage.py
+++ b/yaqd_gage/_pygage.py
@@ -27,9 +27,19 @@ class PyGage(object):
         self.handle = self.get_system()
 
     @compuscope_error_handling
+    def abort_capture(self):
+        """Aborts an acquisition or transfer on the CompuScope system."""
+        return self.interface.AbortCapture(self.handle)
+
+    @compuscope_error_handling
     def commit(self):
         """Commit any configuration changes to device."""
         return self.interface.Commit(self.handle)
+
+    @compuscope_error_handling
+    def free_system(self):
+        """Frees the system associated with the handle"""
+        return self.interface.FreeSystem(self.handle)
 
     @compuscope_error_handling
     def get_acquisition_config(self):

--- a/yaqd_gage/_pygage.py
+++ b/yaqd_gage/_pygage.py
@@ -12,9 +12,10 @@ from ._constants import transfer_modes
 
 def uses_pygage(func):
     """decorator for pygage context management"""
+
     @wraps(func)
     def wrapper(self, *args, **kwargs):
-        pg:PyGage = getattr(self, "_pg", None)
+        pg: PyGage = getattr(self, "_pg", None)
         try:
             return func(self, *args, **kwargs)
         finally:
@@ -22,14 +23,16 @@ def uses_pygage(func):
             # ignore errors, which are probably from closing when already closed
             if isinstance(code, int) and code < 0:
                 self.logger.error(f"{func.__name__} : FreeSystem : {code=}")
+
     return wrapper
 
 
 def async_uses_pygage(func):
     """decorator for async pygage context management"""
+
     @wraps(func)
     async def wrapper(self, *args, **kwargs):
-        pg:PyGage = getattr(self, "_pg", None)
+        pg: PyGage = getattr(self, "_pg", None)
         try:
             return await func(self, *args, **kwargs)
         finally:
@@ -37,6 +40,7 @@ def async_uses_pygage(func):
             # ignore errors, which are probably from closing when already closed
             if isinstance(code, int) and code < 0:
                 self.logger.error(f"{func.__name__} : FreeSystem : {code=}")
+
     return wrapper
 
 

--- a/yaqd_gage/_pygage.py
+++ b/yaqd_gage/_pygage.py
@@ -21,10 +21,10 @@ def uses_pygage(func):
         except Exception as e:
             self.logger.exception(f"error in {func.__name__}")
             code = pg.interface.FreeSystem(pg.handle)
-            # ignore errors, which are probably from closing when already closed
-            if isinstance(code, int) and code < 0:
+            # ignore error -6 (already closed)
+            if code != -6:
                 self.logger.error(f"{func.__name__} : FreeSystem : code={code}")
-            raise e
+                raise e
 
     return wrapper
 
@@ -40,10 +40,10 @@ def async_uses_pygage(func):
         except Exception as e:
             self.logger.exception(f"error in {func.__name__}")
             code = pg.interface.FreeSystem(pg.handle)
-            # ignore errors, which are probably from closing when already closed
-            if isinstance(code, int) and code < 0:
+            # ignore error -6 (already closed)
+            if code != -6:
                 self.logger.error(f"{func.__name__} : FreeSystem : code={code}")
-            raise e
+                raise e
 
     return wrapper
 

--- a/yaqd_gage/_pygage.py
+++ b/yaqd_gage/_pygage.py
@@ -18,11 +18,13 @@ def uses_pygage(func):
         pg: PyGage = getattr(self, "_pg", None)
         try:
             return func(self, *args, **kwargs)
-        finally:
+        except Exception as e:
+            self.logger.exception(f"error in {func.__name__}")
             code = pg.interface.FreeSystem(pg.handle)
             # ignore errors, which are probably from closing when already closed
             if isinstance(code, int) and code < 0:
-                self.logger.error(f"{func.__name__} : FreeSystem : {code=}")
+                self.logger.error(f"{func.__name__} : FreeSystem : code={code}")
+            raise e
 
     return wrapper
 
@@ -35,11 +37,13 @@ def async_uses_pygage(func):
         pg: PyGage = getattr(self, "_pg", None)
         try:
             return await func(self, *args, **kwargs)
-        finally:
+        except Exception as e:
+            self.logger.exception(f"error in {func.__name__}")
             code = pg.interface.FreeSystem(pg.handle)
             # ignore errors, which are probably from closing when already closed
             if isinstance(code, int) and code < 0:
-                self.logger.error(f"{func.__name__} : FreeSystem : {code=}")
+                self.logger.error(f"{func.__name__} : FreeSystem : code={code}")
+            raise e
 
     return wrapper
 

--- a/yaqd_gage/gage-chopping.avpr
+++ b/yaqd_gage/gage-chopping.avpr
@@ -62,7 +62,7 @@
         },
         "mode": {
             "default": 1073741828,
-            "doc": "Sets the operating mode of the CompuScope system. Refer to the CompuScope documentation for valid values. Default is 1073741825 for FirmWare Averaging",
+            "doc": "Sets the operating mode of the CompuScope system. Refer to the CompuScope documentation for valid values. Default is 1073741828 for FirmWare Averaging and four channels.",
             "type": "int"
         },
         "model": {
@@ -253,7 +253,7 @@
             }
         },
         "get_record_count": {
-            "doc": "Get record count.",
+            "doc": "Get the number of acquisitions that are averaged on-board via firmware.",
             "request": [],
             "response": "int"
         },

--- a/yaqd_gage/gage-chopping.toml
+++ b/yaqd_gage/gage-chopping.toml
@@ -62,7 +62,7 @@ fields = [{"name"="min", "type"="double"},
 [config]
 
 [config.mode]
-doc = "Sets the operating mode of the CompuScope system. Refer to the CompuScope documentation for valid values. Default is 1073741825 for FirmWare Averaging"
+doc = "Sets the operating mode of the CompuScope system. Refer to the CompuScope documentation for valid values. Default is 1073741828 for FirmWare Averaging and four channels."
 type = "int"
 default = 0x40000004
 
@@ -162,7 +162,7 @@ doc = "Get a dictionary of 1D arrays of measured segments."
 response = {"type"="map", "values"="ndarray"}
 
 [messages.get_record_count]
-doc = "Get record count."
+doc = "Get the number of acquisitions that are averaged on-board via firmware."
 response = "int"
 
 [messages.get_segment_count]


### PR DESCRIPTION
Factor code that interfaces with the gage board, and wrap these methods with `except` statements that free the resources and prevent the program from freezing. 

Currently, works best when shutdown is called.  The wrappers still do not handle exceptions that occur in other tasks.

Additionally, small revisions to docs in the config specs.

- [ ] test on Waldo

* addresses #32 
* addresses #14