### PR TITLE
correct adc conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+- adc-to-voltage conversion formula now matches that of the SDK docs (64x different from previous formula)
+
 ## [2026.1.0]
 
 ### Added

--- a/yaqd_gage/_pygage.py
+++ b/yaqd_gage/_pygage.py
@@ -9,6 +9,19 @@ from ._exceptions import CompuScopeException
 from ._constants import transfer_modes
 
 
+def to_voltage(adc, repetitions, offset, dc_offset, full_range, resolution):
+    """
+    converts buffer to voltage values as specified from SDK docs:
+    
+    voltage[mV] = (offset - adc_code)/resolution * full_scale_voltage / 2 + dc_offset
+    """
+    adc *= -1 / repetitions
+    adc += offset
+    adc *= full_range / 2000 / resolution
+    adc += dc_offset
+    return adc
+
+
 def compuscope_error_handling(func):
     """Decorator to raise Python exception when appropriate."""
 

--- a/yaqd_gage/_pygage.py
+++ b/yaqd_gage/_pygage.py
@@ -12,7 +12,7 @@ from ._constants import transfer_modes
 def to_voltage(adc, repetitions, offset, dc_offset, full_range, resolution):
     """
     converts buffer to voltage values as specified from SDK docs:
-    
+
     voltage[mV] = (offset - adc_code)/resolution * full_scale_voltage / 2 + dc_offset
     """
     adc *= -1 / repetitions


### PR DESCRIPTION
uses formula provided in SDK to convert to voltage

In a recent development, the old voltage conversion formula (with unexplained factors of both 256 and 1/4, for a total factor of 64) no longer works.  I attribute this to a serendipitous firmware or driver update applied during our OS overhaul.  In any case, it is clear the old formula does not agree with our observed voltages.  

* resolves #3 
* [x] think hard about when to apply the offsets (before or after averaging over cpu-side reps)?
* [x] update changelog
* [x] test on waldo