### PR TITLE
faster data transfers

### DIFF
--- a/.gitlab/CODEOWNERS
+++ b/.gitlab/CODEOWNERS
@@ -1,1 +1,0 @@
-* @ksunden @untzag @kameyer @ddkohler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 - new json schema file for configs
+- gage-chopping: photon counting (new output channels, new property `photon-threshold`
 
 ### Changed
+- config: "impedance mode" is now low, high enum
+- config: "mode" is now an enum
+- gage-compuscope: channel names changed to match those of gage-chopping
+- gage-chopping: record_count property removed
+- daemons no longer support xpert firmware
 - updated SDK: uses python 3.10-3.11
 - adc-to-voltage conversion formula now matches that of the SDK docs (64x different from previous formula)
 
 ### Fixed
+- huge decrease in data transfer time between board and computer
 - daemons will cleanly shut down on error or via client shutdown command (we release the hardware handle)
 
 ## [2026.1.0]

--- a/yaqd_gage/_chopping.py
+++ b/yaqd_gage/_chopping.py
@@ -4,7 +4,7 @@ __all__ = ["CompuScope"]
 import asyncio
 import time
 
-import numpy as np  # type: ignore
+import numpy as np
 
 from ._pygage import PyGage, uses_pygage, async_uses_pygage
 from ._lib import GaGeSynchronous
@@ -12,6 +12,7 @@ from ._lib import GaGeSynchronous
 
 impedences = {"fifty": 50, "onemeg": 1_000_000}
 couplings = {"DC": 1, "AC": 2}
+acq_mode = {"quad": 4, "dual": 2, "single": 1}
 
 
 class CompuScope(GaGeSynchronous):
@@ -24,19 +25,17 @@ class CompuScope(GaGeSynchronous):
         self._max_segment_count = None  # redefined in _config_pygage
         self._tail_size = None
         self._config_pygage()
-        self._channel_names.append("ai1")
-        self._channel_names.append("ai2")
-        self._channel_names.append("ai3")
         for pre in "ap":
+            seed = f"{pre}i{self._config["signal_channel"]}"
             self._channel_names += [
-                f"{pre}i0",
-                f"{pre}i0_a",
-                f"{pre}i0_b",
-                f"{pre}i0_c",
-                f"{pre}i0_d",
-                f"{pre}i0_diff_abcd",
-                f"{pre}i0_diff_ab",
-                f"{pre}i0_diff_ad",
+                f"{seed}",
+                f"{seed}_a",
+                f"{seed}_b",
+                f"{seed}_c",
+                f"{seed}_d",
+                f"{seed}_diff_abcd",
+                f"{seed}_diff_ab",
+                f"{seed}_diff_ad",
             ]
         self._channel_units = {k: "V" if k.startswith("a") else None for k in self._channel_names}
         self._samples: dict[str, np.ndarray] = dict()
@@ -48,7 +47,7 @@ class CompuScope(GaGeSynchronous):
         self.logger.info(acq)
         # acqusition config
         config = {}
-        config["Mode"] = self._config["mode"]
+        config["Mode"] = acq_mode[self._config["mode"]]
         config["SampleRate"] = self._config["sample_rate"]
         config["Depth"] = self._config["depth"]
         config["SegmentSize"] = self._config["segment_size"]
@@ -120,14 +119,16 @@ class CompuScope(GaGeSynchronous):
         self._pg.commit()
         self._max_segment_count = self._pg.max_segment_count
         # start capture
-        # TODO: settable channels for bins, signal
-        shots = await self._capture_and_fetch([0, 3], segment_count)
+        i_sig = self._config["signal_channel"]
+        i_chop = self._config["chop_channel"]
+        ch_indices = set([i_sig, i_chop])
+        shots = await self._capture_and_fetch(ch_indices, segment_count)
 
         self._segments = shots
         t_start = time.time()
         # get edges
         if self._state["edge_width_count"]:
-            gradient = np.gradient(shots["ai3"])
+            gradient = np.gradient(shots[f"ai{i_chop}"])
             edges = np.abs(gradient) > 0.1
             edges = np.convolve(edges, np.full(self._state["edge_width_count"], True), mode="same")
         else:
@@ -137,8 +138,8 @@ class CompuScope(GaGeSynchronous):
         regions = {k: [] for k in self._config["segment_bins"].keys()}
         for k, v in self._config["segment_bins"].items():
             start = None
-            for i, voltage in enumerate(shots["ai3"]):
-                if v["min"] <= voltage <= v["max"] and i != shots["ai3"].size - 1 and not edges[i]:
+            for i, voltage in enumerate(shots[f"ai{i_chop}"]):
+                if v["min"] <= voltage <= v["max"] and i != shots[f"ai{i_chop}"].size - 1 and not edges[i]:
                     if start is None:
                         start = i
                 else:
@@ -151,25 +152,21 @@ class CompuScope(GaGeSynchronous):
         # segments: dict with keys of channel, values are 1D array of 1D arrays
         # count photon events
         # properties: photon_index, photon_threshold (perhaps dictionary for each channel?)
-        counts = np.array([shot > photon_threshold for shot in shots["ai0"]], dtype=bool)
-        out["pi0"] = counts.sum()
-        # take means
-        out["ai0"] = np.mean(shots["ai0"])
-        out["ai1"] = np.nan  # np.mean(segments["ai1"])
-        out["ai2"] = np.nan  # np.mean(segments["ai2"])
-        out["ai3"] = np.mean(shots["ai3"])
+        counts = np.array([shot > photon_threshold for shot in shots[f"ai{i_sig}"]], dtype=bool)
+        out[f"pi{i_sig}"] = counts.sum()
+        # take mean
+        out[f"ai{i_sig}"] = np.mean(shots[f"ai{i_sig}"])
 
         # chopping-derived channels
-        # TODO: remove hard-code ai0, put in config
         for phase in "abcd":
             if regions[phase]:
                 valid = np.r_[tuple(regions[phase])]
-                out[f"pi0_{phase}"] = np.mean(counts[valid])
-                out[f"ai0_{phase}"] = np.mean(shots["ai0"][valid])
+                out[f"pi{i_sig}_{phase}"] = np.mean(counts[valid])
+                out[f"ai{i_sig}_{phase}"] = np.mean(shots[f"ai{i_sig}"][valid])
             else:
                 out[f"pi0_{phase}"] = out[f"ai0_{phase}"] = np.nan
 
-        for key in ["pi0", "ai0"]:
+        for key in [f"pi{i_sig}", f"ai{i_sig}"]:
             out[f"{key}_diff_abcd"] = (
                 out[f"{key}_a"] - out[f"{key}_b"] + out[f"{key}_c"] - out[f"{key}_d"]
             )

--- a/yaqd_gage/_chopping.py
+++ b/yaqd_gage/_chopping.py
@@ -24,6 +24,7 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
         self._pg = PyGage()
         self._channel_names = []
         self._max_segment_count = None  # redefined in _config_pygage
+        self._tail_size = None
         self._config_pygage()
         self._channel_names.append("ai1")
         self._channel_names.append("ai2")
@@ -66,13 +67,13 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
         self._pg.set_acquisition_config(config)
         self._pg.set_multiple_rec_average_count(self._state["record_count"])
         # channel config
+        couplings = {"DC": 1, "AC": 2}
         for channel_index, channel in enumerate(self._config["channels"]):
             self.logger.info(f"{channel_index=}")
             # cfg = self._pg.get_channel_config(channel_index)
             # self.logger.info(cfg)
             config = {}
             config["InputRange"] = channel["range"]
-            couplings = {"DC": 1, "AC": 2}
             config["Coupling"] = couplings[channel["coupling"]]
             config["Impedance"] = impedences[channel["impedance"]]
             config["Filter"] = int(channel["filter"])
@@ -96,6 +97,7 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
             self._pg.set_trigger_config(trigger_index + 1, config)
         # finish
         self._pg.commit()
+        self._tail_size = self._pg.get_segment_tail_size()
         self._max_segment_count = self._pg.max_segment_count
 
     def get_edge_width_count(self) -> int:
@@ -135,14 +137,40 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
                 break
             await asyncio.sleep(0)
         # read out
-        after = time.time()
+        finished_measurement = time.time()
         segments = {}
         segment_count = self._state["segment_count"]
         record_count = self._state["record_count"]
-        for i in range(0, len(self._config["channels"])):
+        # trick the daq into thinking depth is the total size of the data
+        self.total_size = segment_count * (self._config["depth"] + self._tail_size)
+        temp_segment_size = segment_count * (self._config["segment_size"] + self._tail_size)
+        self.logger.info(f"{self.total_size=}, {self._tail_size=}")
+        self._pg.set_acquisition_config(
+            {
+                "Depth" : self.total_size,
+                "SegmentCount": 1,
+                "SegmentSize": temp_segment_size,
+            }
+        )
+        self._pg.commit()
+
+        config = self._pg.get_acquisition_config()
+        self.logger.info(f"{config=}")
+        for i in [0, 3]: #  range(0, len(self._config["channels"])):
             s = await self._process_single_channel(i, segment_count, record_count)
             segments.update(s)
             await asyncio.sleep(0)
+        self._pg.set_acquisition_config(
+            {
+                "Depth" : self._config["depth"], 
+                "SegmentCount": segment_count, 
+                "SegmentSize": self._config["segment_size"]
+            },
+        )
+        self._pg.commit()
+
+        fetched_measurement = time.time()
+
         self._segments = segments
         # get edges
         if self._state["edge_width_count"]:
@@ -174,12 +202,13 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
             await asyncio.sleep(0)
         # segments: dict with keys of channel, values are 1D array of 1D arrays
         # count photon events
+        # properties: photon_index, photon_threshold (perhaps dictionary for each channel?)
         counts = np.array([shot > photon_threshold for shot in segments["ai0"]], dtype=bool)
         out["pi0"] = counts.sum()
         # take means
         out["ai0"] = np.mean(segments["ai0"])
-        out["ai1"] = np.mean(segments["ai1"])
-        out["ai2"] = np.mean(segments["ai2"])
+        out["ai1"] = np.nan  # np.mean(segments["ai1"])
+        out["ai2"] = np.nan  # np.mean(segments["ai2"])
         out["ai3"] = np.mean(segments["ai3"])
 
         # chopping-derived channels
@@ -198,9 +227,10 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
             )
             out[f"{key}_diff_ab"] = out[f"{key}_b"] - out[f"{key}_a"]
             out[f"{key}_diff_ad"] = out[f"{key}_d"] - out[f"{key}_a"]
-        finished = time.time()
-        self.logger.info(f"measurement: {after-before} sec")
-        self.logger.info(f"maths: {finished-after} sec")
+        proceessed_measurement = time.time()
+        self.logger.info(f"measurement: {finished_measurement-before} sec")
+        self.logger.info(f"data xt: {fetched_measurement-finished_measurement} sec")
+        self.logger.info(f"processing: {proceessed_measurement-fetched_measurement} sec")
 
         return out
 
@@ -211,24 +241,27 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
         out[f"ai{channel_index}"] = np.zeros(segment_count, dtype=float)
         system_info = self._pg.get_system_info()
         channel_info = self._pg.get_channel_config(channel_index + 1)
-        for segment_index in range(segment_count):
-            # samples
-            seg = self._pg.transfer_data(
-                channel_index=channel_index + 1,
-                start_position=0,
-                transfer_length=self._config["depth"],
-                segment_index=segment_index + 1,
-                transfer_mode=transfer_modes["data_32"],
-            )[0]
-            seg = np.array(seg, dtype=float)
-            seg = to_voltage(
-                seg,
+
+        segs = self._pg.transfer_data(
+            channel_index=channel_index+1,
+            start_position=0,
+            transfer_length=self.total_size,
+            segment_index=1,
+            transfer_mode=transfer_modes["data_32"]
+        )[0]
+        self.logger.info(f"{segs=}")
+        segs = np.array(segs, dtype=float).reshape(segment_count, -1)
+        segs = to_voltage(
+                segs,
                 record_count,
                 system_info["SampleOffset"],
                 channel_info["DcOffset"],
                 channel_info["InputRange"],
                 system_info["SampleResolution"],
-            )
+        )
+        self.logger.info(segs.shape)
+        for si in range(segs.shape[0]):
+            seg = segs[si]
             self._samples[f"ai{channel_index}"] = seg
 
             # signal
@@ -241,16 +274,15 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
                 start = self._config["channels"][channel_index]["baseline_start_index"]
                 stop = self._config["channels"][channel_index]["baseline_stop_index"]
                 baseline = np.average(seg[start:stop])
-                out[f"ai{channel_index}"][segment_index] = signal - baseline
+                out[f"ai{channel_index}"][si] = signal - baseline
             else:
-                out[f"ai{channel_index}"][segment_index] = signal
+                out[f"ai{channel_index}"][si] = signal
 
             # invert
             if self._config["channels"][channel_index]["invert"]:
-                out[f"ai{channel_index}"][segment_index] *= -1
+                out[f"ai{channel_index}"][si] *= -1
 
             await asyncio.sleep(0)
-
         return out
 
     def close(self):

--- a/yaqd_gage/_chopping.py
+++ b/yaqd_gage/_chopping.py
@@ -147,7 +147,7 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
         self.logger.info(f"{self.total_size=}, {self._tail_size=}")
         self._pg.set_acquisition_config(
             {
-                "Depth" : self.total_size,
+                "Depth": self.total_size,
                 "SegmentCount": 1,
                 "SegmentSize": temp_segment_size,
             }
@@ -156,15 +156,15 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
 
         config = self._pg.get_acquisition_config()
         self.logger.info(f"{config=}")
-        for i in [0, 3]: #  range(0, len(self._config["channels"])):
+        for i in [0, 3]:  #  range(0, len(self._config["channels"])):
             s = await self._process_single_channel(i, segment_count, record_count)
             segments.update(s)
             await asyncio.sleep(0)
         self._pg.set_acquisition_config(
             {
-                "Depth" : self._config["depth"], 
-                "SegmentCount": segment_count, 
-                "SegmentSize": self._config["segment_size"]
+                "Depth": self._config["depth"],
+                "SegmentCount": segment_count,
+                "SegmentSize": self._config["segment_size"],
             },
         )
         self._pg.commit()
@@ -243,21 +243,21 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
         channel_info = self._pg.get_channel_config(channel_index + 1)
 
         segs = self._pg.transfer_data(
-            channel_index=channel_index+1,
+            channel_index=channel_index + 1,
             start_position=0,
             transfer_length=self.total_size,
             segment_index=1,
-            transfer_mode=transfer_modes["data_32"]
+            transfer_mode=transfer_modes["data_32"],
         )[0]
         self.logger.info(f"{segs=}")
         segs = np.array(segs, dtype=float).reshape(segment_count, -1)
         segs = to_voltage(
-                segs,
-                record_count,
-                system_info["SampleOffset"],
-                channel_info["DcOffset"],
-                channel_info["InputRange"],
-                system_info["SampleResolution"],
+            segs,
+            record_count,
+            system_info["SampleOffset"],
+            channel_info["DcOffset"],
+            channel_info["InputRange"],
+            system_info["SampleResolution"],
         )
         self.logger.info(segs.shape)
         for si in range(segs.shape[0]):

--- a/yaqd_gage/_chopping.py
+++ b/yaqd_gage/_chopping.py
@@ -7,9 +7,6 @@ from typing import Dict, Any, List
 
 import numpy as np  # type: ignore
 
-from yaqd_core import HasMeasureTrigger, IsSensor, IsDaemon
-
-from ._constants import acq_status_codes
 from ._pygage import PyGage, uses_pygage, async_uses_pygage
 from ._lib import GaGeSynchronous
 
@@ -131,47 +128,11 @@ class CompuScope(GaGeSynchronous):
         self._pg.commit()
         self._max_segment_count = self._pg.max_segment_count
         # start capture
-        before = time.time()
-        self._pg.start_capture()
-        # wait for capture to complete
-        while True:
-            code = self._pg.get_status()
-            if acq_status_codes[code] == "ACQ_STATUS_READY":
-                break
-            await asyncio.sleep(0)
-        # read out
-        finished_measurement = time.time()
-        shots = {}
-        # trick the daq into thinking depth is the total size of the data
-        self.total_size = segment_count * (self._config["depth"] + self._tail_size)
-        temp_segment_size = segment_count * (self._config["segment_size"] + self._tail_size)
-        self.logger.debug(f"{self.total_size=}, {self._tail_size=}")
-        self._pg.set_acquisition_config(
-            {
-                "Depth": self.total_size,
-                "SegmentCount": 1,
-                "SegmentSize": temp_segment_size,
-            }
-        )
-        self._pg.commit()
-        for i in [0, 3]:
-            shots = self._process_single_channel(
-                self, i, segment_count, record_count, self.total_size
-            )
-            shots.update({f"ai{i}": shots})
-            await asyncio.sleep(0)
-        self._pg.set_acquisition_config(
-            {
-                "Depth": self._config["depth"],
-                "SegmentCount": segment_count,
-                "SegmentSize": self._config["segment_size"],
-            },
-        )
-        self._pg.commit()
-
-        fetched_measurement = time.time()
+        # TODO: settable channels for bins, signal
+        shots = await self._capture_and_fetch([0,3], segment_count, record_count)
 
         self._segments = shots
+        start = time.time()
         # get edges
         if self._state["edge_width_count"]:
             gradient = np.gradient(shots["ai3"])
@@ -223,9 +184,7 @@ class CompuScope(GaGeSynchronous):
             out[f"{key}_diff_ab"] = out[f"{key}_b"] - out[f"{key}_a"]
             out[f"{key}_diff_ad"] = out[f"{key}_d"] - out[f"{key}_a"]
         proceessed_measurement = time.time()
-        self.logger.info(f"measurement: {finished_measurement-before} sec")
-        self.logger.info(f"data xt: {fetched_measurement-finished_measurement} sec")
-        self.logger.info(f"processing: {proceessed_measurement-fetched_measurement} sec")
+        self.logger.info(f"processing: {proceessed_measurement-start} sec")
 
         return out
 

--- a/yaqd_gage/_chopping.py
+++ b/yaqd_gage/_chopping.py
@@ -55,7 +55,7 @@ class CompuScope(GaGeSynchronous):
         self._pg.set_acquisition_config(config)
         # channel config
         for channel_index, channel in enumerate(self._config["channels"]):
-            if channel["record"] or (channel_index == self._config["chop_channel"]):
+            if channel_index in self._config["signal_channels"]:
                 for pre in "ap":
                     seed = f"{pre}i{channel_index}"
                     self._channel_names += [
@@ -68,8 +68,6 @@ class CompuScope(GaGeSynchronous):
                         f"{seed}_diff_ab",
                         f"{seed}_diff_ad",
                     ]
-            else:
-                continue
             cfg = self._pg.get_channel_config(channel_index)
             self.logger.debug(cfg)
             config = {}
@@ -97,7 +95,8 @@ class CompuScope(GaGeSynchronous):
             self._pg.set_trigger_config(trigger_index + 1, config)
         # finish
         self._pg.commit()
-        self._tail_size = self._pg.get_segment_tail_size()
+        # DDK: I guess size is in bits?
+        self._tail_size = self._pg.get_segment_tail_size() // 8
         self._max_segment_count = self._pg.max_segment_count
 
     def get_edge_width_count(self) -> int:
@@ -116,7 +115,7 @@ class CompuScope(GaGeSynchronous):
         self._pg.commit()
         self._max_segment_count = self._pg.max_segment_count
         # start capture
-        i_sigs = self._config["signal_channel"]
+        i_sigs = self._config["signal_channels"]
         i_chop = self._config["chop_channel"]
         ch_indices = set(i_sigs + [i_chop])
         shots = await self._capture_and_fetch(ch_indices, segment_count)
@@ -131,7 +130,7 @@ class CompuScope(GaGeSynchronous):
         else:
             edges = np.full(segment_count, False)
         # get regions
-        self._segments["regions"] = np.full(self._state["segment_count"], "", dtype="<U1")
+        self._segments["regions"] = np.full(segment_count, "", dtype="<U1")
         regions = {k: [] for k in self._config["segment_bins"].keys()}
         for k, v in self._config["segment_bins"].items():
             start = None

--- a/yaqd_gage/_chopping.py
+++ b/yaqd_gage/_chopping.py
@@ -113,9 +113,6 @@ class CompuScope(GaGeSynchronous):
     def get_edge_width_count(self) -> int:
         return self._state["edge_width_count"]
 
-    def get_measured_samples(self):
-        return self._samples
-
     def get_measured_segments(self):
         return self._segments
 

--- a/yaqd_gage/_chopping.py
+++ b/yaqd_gage/_chopping.py
@@ -129,7 +129,7 @@ class CompuScope(GaGeSynchronous):
         self._max_segment_count = self._pg.max_segment_count
         # start capture
         # TODO: settable channels for bins, signal
-        shots = await self._capture_and_fetch([0,3], segment_count, record_count)
+        shots = await self._capture_and_fetch([0, 3], segment_count, record_count)
 
         self._segments = shots
         start = time.time()

--- a/yaqd_gage/_chopping.py
+++ b/yaqd_gage/_chopping.py
@@ -168,11 +168,7 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
                 self, i, segment_count, record_count, self.total_size
             )
             out._samples[f"ai{i}"] = segments[-1]
-            segments.update(
-                {
-                    f"ai{i}": segments
-                }
-            )
+            segments.update({f"ai{i}": segments})
             await asyncio.sleep(0)
         self._pg.set_acquisition_config(
             {

--- a/yaqd_gage/_chopping.py
+++ b/yaqd_gage/_chopping.py
@@ -188,11 +188,7 @@ class CompuScope(GaGeSynchronous):
         for k, v in self._config["segment_bins"].items():
             start = None
             for i, voltage in enumerate(shots["ai3"]):
-                if (
-                    v["min"] <= voltage <= v["max"]
-                    and i != shots["ai3"].size - 1
-                    and not edges[i]
-                ):
+                if v["min"] <= voltage <= v["max"] and i != shots["ai3"].size - 1 and not edges[i]:
                     if start is None:
                         start = i
                 else:

--- a/yaqd_gage/_chopping.py
+++ b/yaqd_gage/_chopping.py
@@ -144,7 +144,7 @@ class CompuScope(GaGeSynchronous):
             await asyncio.sleep(0)
         # read out
         finished_measurement = time.time()
-        segments = {}
+        shots = {}
         # trick the daq into thinking depth is the total size of the data
         self.total_size = segment_count * (self._config["depth"] + self._tail_size)
         temp_segment_size = segment_count * (self._config["segment_size"] + self._tail_size)
@@ -158,11 +158,10 @@ class CompuScope(GaGeSynchronous):
         )
         self._pg.commit()
         for i in [0, 3]:
-            segments = self._process_single_channel(
+            shots = self._process_single_channel(
                 self, i, segment_count, record_count, self.total_size
             )
-            out._samples[f"ai{i}"] = segments[-1]
-            segments.update({f"ai{i}": segments})
+            shots.update({f"ai{i}": shots})
             await asyncio.sleep(0)
         self._pg.set_acquisition_config(
             {
@@ -175,10 +174,10 @@ class CompuScope(GaGeSynchronous):
 
         fetched_measurement = time.time()
 
-        self._segments = segments
+        self._segments = shots
         # get edges
         if self._state["edge_width_count"]:
-            gradient = np.gradient(segments["ai3"])
+            gradient = np.gradient(shots["ai3"])
             edges = np.abs(gradient) > 0.1
             edges = np.convolve(edges, np.full(self._state["edge_width_count"], True), mode="same")
         else:
@@ -188,10 +187,10 @@ class CompuScope(GaGeSynchronous):
         regions = {k: [] for k in self._config["segment_bins"].keys()}
         for k, v in self._config["segment_bins"].items():
             start = None
-            for i, voltage in enumerate(segments["ai3"]):
+            for i, voltage in enumerate(shots["ai3"]):
                 if (
                     v["min"] <= voltage <= v["max"]
-                    and i != segments["ai3"].size - 1
+                    and i != shots["ai3"].size - 1
                     and not edges[i]
                 ):
                     if start is None:
@@ -206,13 +205,13 @@ class CompuScope(GaGeSynchronous):
         # segments: dict with keys of channel, values are 1D array of 1D arrays
         # count photon events
         # properties: photon_index, photon_threshold (perhaps dictionary for each channel?)
-        counts = np.array([shot > photon_threshold for shot in segments["ai0"]], dtype=bool)
+        counts = np.array([shot > photon_threshold for shot in shots["ai0"]], dtype=bool)
         out["pi0"] = counts.sum()
         # take means
-        out["ai0"] = np.mean(segments["ai0"])
+        out["ai0"] = np.mean(shots["ai0"])
         out["ai1"] = np.nan  # np.mean(segments["ai1"])
         out["ai2"] = np.nan  # np.mean(segments["ai2"])
-        out["ai3"] = np.mean(segments["ai3"])
+        out["ai3"] = np.mean(shots["ai3"])
 
         # chopping-derived channels
         # TODO: remove hard-code ai0, put in config
@@ -220,7 +219,7 @@ class CompuScope(GaGeSynchronous):
             if regions[phase]:
                 valid = np.r_[tuple(regions[phase])]
                 out[f"pi0_{phase}"] = np.mean(counts[valid])
-                out[f"ai0_{phase}"] = np.mean(segments["ai0"][valid])
+                out[f"ai0_{phase}"] = np.mean(shots["ai0"][valid])
             else:
                 out[f"pi0_{phase}"] = out[f"ai0_{phase}"] = np.nan
 

--- a/yaqd_gage/_chopping.py
+++ b/yaqd_gage/_chopping.py
@@ -3,7 +3,6 @@ __all__ = ["CompuScope"]
 
 import asyncio
 import time
-from typing import Dict, Any, List
 
 import numpy as np  # type: ignore
 
@@ -40,8 +39,8 @@ class CompuScope(GaGeSynchronous):
                 f"{pre}i0_diff_ad",
             ]
         self._channel_units = {k: "V" if k.startswith("a") else None for k in self._channel_names}
-        self._samples: Dict[str, np.ndarray] = dict()
-        self._segments: Dict[str, np.ndarray] = dict()
+        self._samples: dict[str, np.ndarray] = dict()
+        self._segments: dict[str, np.ndarray] = dict()
 
     @uses_pygage
     def _config_pygage(self):
@@ -72,7 +71,6 @@ class CompuScope(GaGeSynchronous):
             self.logger.info(f"{k}: {acq.get(k)} | {config.get(k)}")
         config["SegmentCount"] = self._state["segment_count"]
         self._pg.set_acquisition_config(config)
-        self._pg.set_multiple_rec_average_count(self._state["record_count"])
         # channel config
         for channel_index, channel in enumerate(self._config["channels"]):
             self.logger.info(f"{channel_index=}")
@@ -112,23 +110,18 @@ class CompuScope(GaGeSynchronous):
     def get_measured_segments(self):
         return self._segments
 
-    def get_record_count(self) -> int:
-        return self._state["record_count"]
-
     @async_uses_pygage
     async def _measure(self):
         out = dict()
         # apply state variables
         photon_threshold = self._state["photon_threshold"]
         segment_count = self._state["segment_count"]
-        record_count = self._state["record_count"]
         self._pg.set_acquisition_config({"SegmentCount": segment_count})
-        self._pg.set_multiple_rec_average_count(record_count)
         self._pg.commit()
         self._max_segment_count = self._pg.max_segment_count
         # start capture
         # TODO: settable channels for bins, signal
-        shots = await self._capture_and_fetch([0, 3], segment_count, record_count)
+        shots = await self._capture_and_fetch([0, 3], segment_count)
 
         self._segments = shots
         t_start = time.time()
@@ -190,9 +183,6 @@ class CompuScope(GaGeSynchronous):
     def set_edge_width_count(self, count: int) -> None:
         assert count >= 0  # no limits_getter atm
         self._state["edge_width_count"] = count
-
-    def set_record_count(self, count: int) -> None:
-        self._state["record_count"] = count
 
     def set_photon_threshold(self, threshold) -> None:
         self._state["photon_threshold"] = threshold

--- a/yaqd_gage/_chopping.py
+++ b/yaqd_gage/_chopping.py
@@ -122,12 +122,6 @@ class CompuScope(GaGeSynchronous):
     def get_record_count(self) -> int:
         return self._state["record_count"]
 
-    def get_segment_count(self) -> int:
-        return self._state["segment_count"]
-
-    def get_segment_count_limits(self) -> List[int]:
-        return [1, self._max_segment_count]
-
     @async_uses_pygage
     async def _measure(self):
         out = dict()
@@ -243,18 +237,12 @@ class CompuScope(GaGeSynchronous):
 
         return out
 
-    def close(self):
-        self._pg.free_system()
-
     def set_edge_width_count(self, count: int) -> None:
         assert count >= 0  # no limits_getter atm
         self._state["edge_width_count"] = count
 
     def set_record_count(self, count: int) -> None:
         self._state["record_count"] = count
-
-    def set_segment_count(self, count: int) -> None:
-        self._state["segment_count"] = count
 
     def set_photon_threshold(self, threshold) -> None:
         self._state["photon_threshold"] = threshold

--- a/yaqd_gage/_chopping.py
+++ b/yaqd_gage/_chopping.py
@@ -7,12 +7,7 @@ import time
 import numpy as np
 
 from ._pygage import PyGage, uses_pygage, async_uses_pygage
-from ._lib import GaGeSynchronous
-
-
-impedences = {"fifty": 50, "onemeg": 1_000_000}
-couplings = {"DC": 1, "AC": 2}
-acq_mode = {"quad": 4, "dual": 2, "single": 1}
+from ._lib import GaGeSynchronous, impedances, couplings, acq_mode
 
 
 class CompuScope(GaGeSynchronous):
@@ -78,7 +73,7 @@ class CompuScope(GaGeSynchronous):
             config = {}
             config["InputRange"] = channel["range"]
             config["Coupling"] = couplings[channel["coupling"]]
-            config["Impedance"] = impedences[channel["impedance"]]
+            config["Impedance"] = impedances[channel["impedance"]]
             config["Filter"] = int(channel["filter"])
             config["DcOffset"] = channel["dc_offset"]
             self._pg.set_channel_config(channel_index + 1, config)
@@ -91,7 +86,7 @@ class CompuScope(GaGeSynchronous):
             config["Level"] = int(trigger["level"])
             config["Source"] = trigger["source"]
             config["ExtRange"] = trigger["range"]
-            config["ExtImpedance"] = impedences[channel["impedance"]]
+            config["ExtImpedance"] = impedances[channel["impedance"]]
             config["ExtCoupling"] = couplings[channel["coupling"]]
             config["Relation"] = 0
             for k in tcfg:

--- a/yaqd_gage/_chopping.py
+++ b/yaqd_gage/_chopping.py
@@ -9,8 +9,9 @@ import numpy as np  # type: ignore
 
 from yaqd_core import HasMeasureTrigger, IsSensor, IsDaemon
 
-from ._constants import acq_status_codes, transfer_modes
-from ._pygage import PyGage, uses_pygage, async_uses_pygage, to_voltage
+from ._constants import acq_status_codes
+from ._pygage import PyGage, uses_pygage, async_uses_pygage
+from ._lib import _process_single_channel
 
 
 impedences = {"fifty": 50, "onemeg": 1_000_000}
@@ -59,7 +60,16 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
         config["TriggerTimeout"] = self._config["trigger_time_out"]
         config["TriggerHoldoff"] = self._config["trigger_hold_off"]
         config["ExtClk"] = int(self._config["ext_clk"])
-        config["TimeStampConfig"] = 0
+
+        if False:  # TODO: test this
+            timestamp_config = 0x00
+            if self._config["time_stamp_clock"] == "fixed":
+                timestamp_config |= 0x1
+            if self._config["time_stamp_mode"] == "free":
+                timestamp_config |= 0x10
+            config["TimeStampConfig"] = timestamp_config
+        else:
+            config["TimeStampConfig"] = 0
         # from state
         for k in config:
             self.logger.info(f"{k}: {acq.get(k)} | {config.get(k)}")
@@ -123,8 +133,10 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
         out = dict()
         # apply state variables
         photon_threshold = self._state["photon_threshold"]
-        self._pg.set_acquisition_config({"SegmentCount": self._state["segment_count"]})
-        self._pg.set_multiple_rec_average_count(self._state["record_count"])
+        segment_count = self._state["segment_count"]
+        record_count = self._state["record_count"]
+        self._pg.set_acquisition_config({"SegmentCount": segment_count})
+        self._pg.set_multiple_rec_average_count(record_count)
         self._pg.commit()
         self._max_segment_count = self._pg.max_segment_count
         # start capture
@@ -139,12 +151,10 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
         # read out
         finished_measurement = time.time()
         segments = {}
-        segment_count = self._state["segment_count"]
-        record_count = self._state["record_count"]
         # trick the daq into thinking depth is the total size of the data
         self.total_size = segment_count * (self._config["depth"] + self._tail_size)
         temp_segment_size = segment_count * (self._config["segment_size"] + self._tail_size)
-        self.logger.info(f"{self.total_size=}, {self._tail_size=}")
+        self.logger.debug(f"{self.total_size=}, {self._tail_size=}")
         self._pg.set_acquisition_config(
             {
                 "Depth": self.total_size,
@@ -153,12 +163,16 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
             }
         )
         self._pg.commit()
-
-        config = self._pg.get_acquisition_config()
-        self.logger.info(f"{config=}")
-        for i in [0, 3]:  #  range(0, len(self._config["channels"])):
-            s = await self._process_single_channel(i, segment_count, record_count)
-            segments.update(s)
+        for i in [0, 3]:
+            segments = _process_single_channel(
+                self, i, segment_count, record_count, self.total_size
+            )
+            out._samples[f"ai{i}"] = segments[-1]
+            segments.update(
+                {
+                    f"ai{i}": segments
+                }
+            )
             await asyncio.sleep(0)
         self._pg.set_acquisition_config(
             {
@@ -179,7 +193,6 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
             edges = np.convolve(edges, np.full(self._state["edge_width_count"], True), mode="same")
         else:
             edges = np.full(segment_count, False)
-        await asyncio.sleep(0)
         # get regions
         self._segments["regions"] = np.full(self._state["segment_count"], "", dtype="<U1")
         regions = {k: [] for k in self._config["segment_bins"].keys()}
@@ -232,57 +245,6 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
         self.logger.info(f"data xt: {fetched_measurement-finished_measurement} sec")
         self.logger.info(f"processing: {proceessed_measurement-fetched_measurement} sec")
 
-        return out
-
-    async def _process_single_channel(
-        self, channel_index: int, segment_count: int, record_count: int
-    ) -> Dict[str, Any]:
-        out = dict()
-        out[f"ai{channel_index}"] = np.zeros(segment_count, dtype=float)
-        system_info = self._pg.get_system_info()
-        channel_info = self._pg.get_channel_config(channel_index + 1)
-
-        segs = self._pg.transfer_data(
-            channel_index=channel_index + 1,
-            start_position=0,
-            transfer_length=self.total_size,
-            segment_index=1,
-            transfer_mode=transfer_modes["data_32"],
-        )[0]
-        self.logger.info(f"{segs=}")
-        segs = np.array(segs, dtype=float).reshape(segment_count, -1)
-        segs = to_voltage(
-            segs,
-            record_count,
-            system_info["SampleOffset"],
-            channel_info["DcOffset"],
-            channel_info["InputRange"],
-            system_info["SampleResolution"],
-        )
-        self.logger.info(segs.shape)
-        for si in range(segs.shape[0]):
-            seg = segs[si]
-            self._samples[f"ai{channel_index}"] = seg
-
-            # signal
-            start = self._config["channels"][channel_index]["signal_start_index"]
-            stop = self._config["channels"][channel_index]["signal_stop_index"]
-            signal = np.average(seg[start:stop])
-
-            # baseline
-            if self._config["channels"][channel_index]["use_baseline"]:
-                start = self._config["channels"][channel_index]["baseline_start_index"]
-                stop = self._config["channels"][channel_index]["baseline_stop_index"]
-                baseline = np.average(seg[start:stop])
-                out[f"ai{channel_index}"][si] = signal - baseline
-            else:
-                out[f"ai{channel_index}"][si] = signal
-
-            # invert
-            if self._config["channels"][channel_index]["invert"]:
-                out[f"ai{channel_index}"][si] *= -1
-
-            await asyncio.sleep(0)
         return out
 
     def close(self):

--- a/yaqd_gage/_chopping.py
+++ b/yaqd_gage/_chopping.py
@@ -12,6 +12,7 @@ from ._lib import GaGeSynchronous
 
 
 impedences = {"fifty": 50, "onemeg": 1_000_000}
+couplings = {"DC": 1, "AC": 2}
 
 
 class CompuScope(GaGeSynchronous):
@@ -57,7 +58,6 @@ class CompuScope(GaGeSynchronous):
         config["TriggerTimeout"] = self._config["trigger_time_out"]
         config["TriggerHoldoff"] = self._config["trigger_hold_off"]
         config["ExtClk"] = int(self._config["ext_clk"])
-
         if False:  # TODO: test this
             timestamp_config = 0x00
             if self._config["time_stamp_clock"] == "fixed":
@@ -74,7 +74,6 @@ class CompuScope(GaGeSynchronous):
         self._pg.set_acquisition_config(config)
         self._pg.set_multiple_rec_average_count(self._state["record_count"])
         # channel config
-        couplings = {"DC": 1, "AC": 2}
         for channel_index, channel in enumerate(self._config["channels"]):
             self.logger.info(f"{channel_index=}")
             # cfg = self._pg.get_channel_config(channel_index)
@@ -132,7 +131,7 @@ class CompuScope(GaGeSynchronous):
         shots = await self._capture_and_fetch([0, 3], segment_count, record_count)
 
         self._segments = shots
-        start = time.time()
+        t_start = time.time()
         # get edges
         if self._state["edge_width_count"]:
             gradient = np.gradient(shots["ai3"])
@@ -183,8 +182,8 @@ class CompuScope(GaGeSynchronous):
             )
             out[f"{key}_diff_ab"] = out[f"{key}_b"] - out[f"{key}_a"]
             out[f"{key}_diff_ad"] = out[f"{key}_d"] - out[f"{key}_a"]
-        proceessed_measurement = time.time()
-        self.logger.info(f"processing: {proceessed_measurement-start} sec")
+        t_processed = time.time()
+        self.logger.info(f"processing: {t_processed-t_start} sec")
 
         return out
 

--- a/yaqd_gage/_chopping.py
+++ b/yaqd_gage/_chopping.py
@@ -26,7 +26,7 @@ class CompuScope(GaGeSynchronous):
         self._tail_size = None
         self._config_pygage()
         for pre in "ap":
-            seed = f"{pre}i{self._config["signal_channel"]}"
+            seed = f"{pre}i{self._config['signal_channel']}"
             self._channel_names += [
                 f"{seed}",
                 f"{seed}_a",

--- a/yaqd_gage/_chopping.py
+++ b/yaqd_gage/_chopping.py
@@ -20,18 +20,6 @@ class CompuScope(GaGeSynchronous):
         self._max_segment_count = None  # redefined in _config_pygage
         self._tail_size = None
         self._config_pygage()
-        for pre in "ap":
-            seed = f"{pre}i{self._config['signal_channel']}"
-            self._channel_names += [
-                f"{seed}",
-                f"{seed}_a",
-                f"{seed}_b",
-                f"{seed}_c",
-                f"{seed}_d",
-                f"{seed}_diff_abcd",
-                f"{seed}_diff_ab",
-                f"{seed}_diff_ad",
-            ]
         self._channel_units = {k: "V" if k.startswith("a") else None for k in self._channel_names}
         self._samples: dict[str, np.ndarray] = dict()
         self._segments: dict[str, np.ndarray] = dict()
@@ -67,9 +55,23 @@ class CompuScope(GaGeSynchronous):
         self._pg.set_acquisition_config(config)
         # channel config
         for channel_index, channel in enumerate(self._config["channels"]):
-            self.logger.info(f"{channel_index=}")
-            # cfg = self._pg.get_channel_config(channel_index)
-            # self.logger.info(cfg)
+            if channel["record"] or (channel_index == self._config["chop_channel"]):
+                for pre in "ap":
+                    seed = f"{pre}i{channel_index}"
+                    self._channel_names += [
+                        f"{seed}",
+                        f"{seed}_a",
+                        f"{seed}_b",
+                        f"{seed}_c",
+                        f"{seed}_d",
+                        f"{seed}_diff_abcd",
+                        f"{seed}_diff_ab",
+                        f"{seed}_diff_ad",
+                    ]
+            else:
+                continue
+            cfg = self._pg.get_channel_config(channel_index)
+            self.logger.debug(cfg)
             config = {}
             config["InputRange"] = channel["range"]
             config["Coupling"] = couplings[channel["coupling"]]
@@ -114,9 +116,9 @@ class CompuScope(GaGeSynchronous):
         self._pg.commit()
         self._max_segment_count = self._pg.max_segment_count
         # start capture
-        i_sig = self._config["signal_channel"]
+        i_sigs = self._config["signal_channel"]
         i_chop = self._config["chop_channel"]
-        ch_indices = set([i_sig, i_chop])
+        ch_indices = set(i_sigs + [i_chop])
         shots = await self._capture_and_fetch(ch_indices, segment_count)
 
         self._segments = shots
@@ -149,28 +151,27 @@ class CompuScope(GaGeSynchronous):
                         start = None
             await asyncio.sleep(0)
         # segments: dict with keys of channel, values are 1D array of 1D arrays
-        # count photon events
-        # properties: photon_index, photon_threshold (perhaps dictionary for each channel?)
-        counts = np.array([shot > photon_threshold for shot in shots[f"ai{i_sig}"]], dtype=bool)
-        out[f"pi{i_sig}"] = counts.sum()
-        # take mean
-        out[f"ai{i_sig}"] = np.mean(shots[f"ai{i_sig}"])
+        for i_sig in i_sigs:
+            counts = np.array([shot > photon_threshold for shot in shots[f"ai{i_sig}"]], dtype=bool)
+            out[f"pi{i_sig}"] = counts.sum()
+            # take mean
+            out[f"ai{i_sig}"] = np.mean(shots[f"ai{i_sig}"])
 
-        # chopping-derived channels
-        for phase in "abcd":
-            if regions[phase]:
-                valid = np.r_[tuple(regions[phase])]
-                out[f"pi{i_sig}_{phase}"] = np.mean(counts[valid])
-                out[f"ai{i_sig}_{phase}"] = np.mean(shots[f"ai{i_sig}"][valid])
-            else:
-                out[f"pi0_{phase}"] = out[f"ai0_{phase}"] = np.nan
+            # chopping-derived channels
+            for phase in "abcd":
+                if regions[phase]:
+                    valid = np.r_[tuple(regions[phase])]
+                    out[f"pi{i_sig}_{phase}"] = np.mean(counts[valid])
+                    out[f"ai{i_sig}_{phase}"] = np.mean(shots[f"ai{i_sig}"][valid])
+                else:
+                    out[f"pi{i_sig}_{phase}"] = out[f"ai{i_sig}_{phase}"] = np.nan
 
-        for key in [f"pi{i_sig}", f"ai{i_sig}"]:
-            out[f"{key}_diff_abcd"] = (
-                out[f"{key}_a"] - out[f"{key}_b"] + out[f"{key}_c"] - out[f"{key}_d"]
-            )
-            out[f"{key}_diff_ab"] = out[f"{key}_b"] - out[f"{key}_a"]
-            out[f"{key}_diff_ad"] = out[f"{key}_d"] - out[f"{key}_a"]
+            for key in [f"pi{i_sig}", f"ai{i_sig}"]:
+                out[f"{key}_diff_abcd"] = (
+                    out[f"{key}_a"] - out[f"{key}_b"] + out[f"{key}_c"] - out[f"{key}_d"]
+                )
+                out[f"{key}_diff_ab"] = out[f"{key}_b"] - out[f"{key}_a"]
+                out[f"{key}_diff_ad"] = out[f"{key}_d"] - out[f"{key}_a"]
         t_processed = time.time()
         self.logger.info(f"processing: {t_processed-t_start} sec")
 

--- a/yaqd_gage/_chopping.py
+++ b/yaqd_gage/_chopping.py
@@ -139,7 +139,11 @@ class CompuScope(GaGeSynchronous):
         for k, v in self._config["segment_bins"].items():
             start = None
             for i, voltage in enumerate(shots[f"ai{i_chop}"]):
-                if v["min"] <= voltage <= v["max"] and i != shots[f"ai{i_chop}"].size - 1 and not edges[i]:
+                if (
+                    v["min"] <= voltage <= v["max"]
+                    and i != shots[f"ai{i_chop}"].size - 1
+                    and not edges[i]
+                ):
                     if start is None:
                         start = i
                 else:

--- a/yaqd_gage/_chopping.py
+++ b/yaqd_gage/_chopping.py
@@ -152,7 +152,9 @@ class CompuScope(GaGeSynchronous):
             await asyncio.sleep(0)
         # segments: dict with keys of channel, values are 1D array of 1D arrays
         for i_sig in i_sigs:
-            counts = np.array([shot > photon_threshold for shot in shots[f"ai{i_sig}"]], dtype=bool)
+            counts = np.array(
+                [shot > photon_threshold for shot in shots[f"ai{i_sig}"]], dtype=bool
+            )
             out[f"pi{i_sig}"] = counts.sum()
             # take mean
             out[f"ai{i_sig}"] = np.mean(shots[f"ai{i_sig}"])

--- a/yaqd_gage/_chopping.py
+++ b/yaqd_gage/_chopping.py
@@ -147,8 +147,6 @@ class CompuScope(GaGeSynchronous):
                         regions[k].append(sl)
                         self._segments["regions"][sl] = k
                         start = None
-            await asyncio.sleep(0)
-        # segments: dict with keys of channel, values are 1D array of 1D arrays
         for i_sig in i_sigs:
             counts = np.array(
                 [shot > photon_threshold for shot in shots[f"ai{i_sig}"]], dtype=bool

--- a/yaqd_gage/_chopping.py
+++ b/yaqd_gage/_chopping.py
@@ -68,8 +68,7 @@ class CompuScope(GaGeSynchronous):
                         f"{seed}_diff_ab",
                         f"{seed}_diff_ad",
                     ]
-            cfg = self._pg.get_channel_config(channel_index)
-            self.logger.debug(cfg)
+            self.logger.debug(f"{self._pg.get_channel_config(channel_index+1)=}")
             config = {}
             config["InputRange"] = channel["range"]
             config["Coupling"] = couplings[channel["coupling"]]

--- a/yaqd_gage/_chopping.py
+++ b/yaqd_gage/_chopping.py
@@ -11,13 +11,13 @@ from yaqd_core import HasMeasureTrigger, IsSensor, IsDaemon
 
 from ._constants import acq_status_codes
 from ._pygage import PyGage, uses_pygage, async_uses_pygage
-from ._lib import _process_single_channel
+from ._lib import GaGeSynchronous
 
 
 impedences = {"fifty": 50, "onemeg": 1_000_000}
 
 
-class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
+class CompuScope(GaGeSynchronous):
     _kind = "gage-chopping"
 
     def __init__(self, name, config, config_filepath):
@@ -164,7 +164,7 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
         )
         self._pg.commit()
         for i in [0, 3]:
-            segments = _process_single_channel(
+            segments = self._process_single_channel(
                 self, i, segment_count, record_count, self.total_size
             )
             out._samples[f"ai{i}"] = segments[-1]

--- a/yaqd_gage/_compuscope.py
+++ b/yaqd_gage/_compuscope.py
@@ -3,20 +3,18 @@ __all__ = ["CompuScope"]
 
 import asyncio
 import time
-from typing import Dict, Any, List
+from typing import Dict, List
 
-import numpy as np  # type: ignore
-
-from yaqd_core import HasMeasureTrigger, IsSensor, IsDaemon
+import numpy as np
 
 from ._constants import acq_status_codes, transfer_modes
 from ._pygage import PyGage, uses_pygage, async_uses_pygage, to_voltage
-from ._lib import process_single_channel
+from ._lib import GaGeSynchronous
 
 impedences = {"fifty": 50, "onemeg": 1_000_000}
 
 
-class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
+class CompuScope(GaGeSynchronous):
     _kind = "gage-compuscope"
 
     def __init__(self, name, config, config_filepath):
@@ -119,7 +117,7 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
         for i in range(0, len(self._config["channels"])):
             out.update(
                 {
-                    f"ai{i}": process_single_channel(
+                    f"ai{i}": self._process_single_channel(
                         self,
                         i,
                         segment_count,
@@ -139,51 +137,6 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
         self._pg.commit()
 
         self.logger.debug(out)
-        return out
-
-    def _process_single_channel(self, channel_index: int) -> Dict[str, float]:
-        out = dict()
-        # TODO: think about perhaps other dtypes
-        buffer = np.zeros(self._config["depth"], dtype=float)
-        system_info = self._pg.get_system_info()
-        channel_info = self._pg.get_channel_config(channel_index + 1)
-        for segment in range(self._state["segment_count"]):
-            seg = self._pg.transfer_data(
-                channel_index=channel_index + 1,
-                start_position=0,
-                transfer_length=self._config["depth"],
-                segment_index=segment + 1,
-                transfer_mode=transfer_modes["data_32"],
-            )[0]
-            seg = np.array(seg, dtype=float)
-            buffer += seg
-        # process samples array
-        buffer = to_voltage(
-            buffer,
-            self._state["segment_count"] * self._config["record_count"],
-            system_info["SampleOffset"],
-            channel_info["DcOffset"],
-            channel_info["InputRange"],
-            system_info["SampleResolution"],
-        )
-        self._samples[f"channel{channel_index+1}"] = buffer
-        # signal
-        start = self._config["channels"][channel_index]["signal_start_index"]
-        stop = self._config["channels"][channel_index]["signal_stop_index"]
-        signal = np.average(buffer[start:stop])
-        # baseline
-        if self._config["channels"][channel_index]["use_baseline"]:
-            start = self._config["channels"][channel_index]["baseline_start_index"]
-            stop = self._config["channels"][channel_index]["baseline_stop_index"]
-            baseline = np.average(buffer[start:stop])
-            out[f"channel{channel_index+1}"] = signal - baseline
-            out[f"channel{channel_index+1}_signal"] = signal
-            out[f"channel{channel_index+1}_baseline"] = baseline
-        else:
-            out[f"channel{channel_index+1}"] = signal
-        # invert
-        if self._config["channels"][channel_index]["invert"]:
-            out[f"channel{channel_index+1}"] *= -1
         return out
 
     def close(self):

--- a/yaqd_gage/_compuscope.py
+++ b/yaqd_gage/_compuscope.py
@@ -79,12 +79,6 @@ class CompuScope(GaGeSynchronous):
     def get_measured_samples(self):
         return self._samples
 
-    def get_segment_count(self) -> int:
-        return self._state["segment_count"]
-
-    def get_segment_count_limits(self) -> List[int]:
-        return [1, self._max_segment_count]
-
     @async_uses_pygage
     async def _measure(self):
         # apply state
@@ -138,10 +132,3 @@ class CompuScope(GaGeSynchronous):
 
         self.logger.debug(out)
         return out
-
-    def close(self):
-        self._pg.free_system()
-
-    def set_segment_count(self, count: int) -> None:
-        assert count <= self._max_segment_count
-        self._state["segment_count"] = count

--- a/yaqd_gage/_compuscope.py
+++ b/yaqd_gage/_compuscope.py
@@ -12,6 +12,7 @@ from ._pygage import PyGage, uses_pygage, async_uses_pygage
 from ._lib import GaGeSynchronous
 
 impedences = {"fifty": 50, "onemeg": 1_000_000}
+couplings = {"DC": 1, "AC": 2}
 
 
 class CompuScope(GaGeSynchronous):
@@ -24,10 +25,7 @@ class CompuScope(GaGeSynchronous):
         self._max_segment_count = None  # redefined in _config_pygage
         self._config_pygage()
         for i in range(0, len(self._config["channels"])):
-            self._channel_names.append(f"channel{i+1}")
-            if self._config["channels"][i]["use_baseline"]:
-                self._channel_names.append(f"channel{i+1}_signal")
-                self._channel_names.append(f"channel{i+1}_baseline")
+            self._channel_names.append(f"ai{i}")
         self._channel_units = {k: "V" for k in self._channel_names}
         self._samples: Dict[str, np.ndarray] = dict()
         self.set_segment_count(self._state["segment_count"])
@@ -41,11 +39,19 @@ class CompuScope(GaGeSynchronous):
         config["Depth"] = self._config["depth"]
         config["SegmentSize"] = self._config["segment_size"]
         config["TriggerDelay"] = self._config["trigger_delay"]
-        config["TriggerTimeOut"] = self._config["trigger_time_out"]
-        config["TriggerHoldOff"] = self._config["trigger_hold_off"]
+        config["SegmentCount"] = self._state["segment_count"]
+        config["TriggerTimeout"] = self._config["trigger_time_out"]
+        config["TriggerHoldoff"] = self._config["trigger_hold_off"]
         config["ExtClk"] = int(self._config["ext_clk"])
-        config["TimeStampMode"] = self._config["time_stamp_mode"]
-        config["TimeStampClock"] = self._config["time_stamp_clock"]
+        if False:  # TODO: test this
+            timestamp_config = 0x00
+            if self._config["time_stamp_clock"] == "fixed":
+                timestamp_config |= 0x1
+            if self._config["time_stamp_mode"] == "free":
+                timestamp_config |= 0x10
+            config["TimeStampConfig"] = timestamp_config
+        else:
+            config["TimeStampConfig"] = 0
         # from state
         config["SegmentCount"] = self._state["segment_count"]
         self._pg.set_acquisition_config(config)
@@ -54,11 +60,8 @@ class CompuScope(GaGeSynchronous):
         for channel_index, channel in enumerate(self._config["channels"]):
             config = {}
             config["InputRange"] = channel["range"]
-            couplings = {"DC": 1, "AC": 2}
             config["Coupling"] = couplings[channel["coupling"]]
             config["Impedance"] = impedences[channel["impedance"]]
-            config["DiffInput"] = int(channel["diff_input"])
-            config["DirectADC"] = int(channel["direct_adc"])
             config["Filter"] = int(channel["filter"])
             config["DcOffset"] = channel["dc_offset"]
             self._pg.set_channel_config(channel_index + 1, config)
@@ -66,37 +69,44 @@ class CompuScope(GaGeSynchronous):
         for trigger_index, trigger in enumerate(self._config["triggers"]):
             config = {}
             config["Condition"] = trigger["condition"]
-            config["Level"] = trigger["level"]
+            config["Level"] = int(trigger["level"])
             config["Source"] = trigger["source"]
-            config["InputRange"] = trigger["range"]
-            config["Impedance"] = impedences[channel["impedance"]]
+            config["ExtRange"] = trigger["range"]
+            config["ExtImpedance"] = impedences[channel["impedance"]]
+            config["ExtCoupling"] = couplings[channel["coupling"]]
             config["Relation"] = 0
             self._pg.set_trigger_config(trigger_index + 1, config)
         # finish
         self._pg.commit()
+        self._tail_size = self._pg.get_segment_tail_size()
         self._max_segment_count = self._pg.max_segment_count
 
     @async_uses_pygage
     async def _measure(self):
         # apply state
-        segment_count = self._state["segment_count"]
-        self._pg.set_acquisition_config({"SegmentCount": segment_count})
-        self._pg.commit()
-        # start capture
-        self._pg.start_capture()
-        # wait for capture to complete
-        before = time.time()
-        while True:
-            code = self._pg.get_status()
-            if acq_status_codes[code] == "ACQ_STATUS_READY":
-                break
-            await asyncio.sleep(0)
-        self.logger.debug("TIME WAITED", time.time() - before)
-        # read out
-        out = await self._process_ai_channels(
-            [_ for _ in range(len(self._config["channels"]))],
-            segment_count,
-        )
+        try:
+            segment_count = self._state["segment_count"]
+            self._pg.set_acquisition_config({"SegmentCount": segment_count})
+            self._pg.commit()
+            # start capture
+            self._pg.start_capture()
+            # wait for capture to complete
+            before = time.time()
+            while True:
+                code = self._pg.get_status()
+                if acq_status_codes[code] == "ACQ_STATUS_READY":
+                    break
+                await asyncio.sleep(0)
+            self.logger.debug("TIME WAITED", time.time() - before)
+            # read out
+            self.logger.info("here")
+            out = await self._capture_and_fetch(
+                [_ for _ in range(len(self._config["channels"]))],
+                segment_count,
+            )
 
-        self.logger.debug(out)
+            # self.logger.info(out)
+        except Exception as e:
+            self.logger.error(e, exc_info=True)
+            raise e
         return out

--- a/yaqd_gage/_compuscope.py
+++ b/yaqd_gage/_compuscope.py
@@ -3,7 +3,7 @@ __all__ = ["CompuScope"]
 
 import asyncio
 import time
-from typing import Dict, List
+from typing import Dict
 
 import numpy as np
 
@@ -75,9 +75,6 @@ class CompuScope(GaGeSynchronous):
         # finish
         self._pg.commit()
         self._max_segment_count = self._pg.max_segment_count
-
-    def get_measured_samples(self):
-        return self._samples
 
     @async_uses_pygage
     async def _measure(self):

--- a/yaqd_gage/_compuscope.py
+++ b/yaqd_gage/_compuscope.py
@@ -93,39 +93,10 @@ class CompuScope(GaGeSynchronous):
             await asyncio.sleep(0)
         self.logger.debug("TIME WAITED", time.time() - before)
         # read out
-        total_size = segment_count * (self._config["depth"] + self._tail_size)
-        temp_segment_size = segment_count * (self._config["segment_size"] + self._tail_size)
-        self._pg.set_acquisition_config(
-            {
-                "Depth": self.total_size,
-                "SegmentCount": 1,
-                "SegmentSize": temp_segment_size,
-            }
+        out = await self._process_ai_channels(
+            [_ for _ in range(len(self._config["channels"]))],
+            segment_count,
         )
-        self._pg.commit()
-
-        out = {}
-        for i in range(0, len(self._config["channels"])):
-            out.update(
-                {
-                    f"ai{i}": self._process_single_channel(
-                        self,
-                        i,
-                        segment_count,
-                        1,
-                    )
-                }
-            )
-            await asyncio.sleep(0)
-
-        self._pg.set_acquisition_config(
-            {
-                "Depth": self._config["depth"],
-                "SegmentCount": segment_count,
-                "SegmentSize": self._config["segment_size"],
-            },
-        )
-        self._pg.commit()
 
         self.logger.debug(out)
         return out

--- a/yaqd_gage/_compuscope.py
+++ b/yaqd_gage/_compuscope.py
@@ -11,7 +11,7 @@ from yaqd_core import HasMeasureTrigger, IsSensor, IsDaemon
 
 from ._constants import acq_status_codes, transfer_modes
 from ._pygage import PyGage, uses_pygage, async_uses_pygage, to_voltage
-
+from ._lib import process_single_channel
 
 impedences = {"fifty": 50, "onemeg": 1_000_000}
 
@@ -90,7 +90,8 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
     @async_uses_pygage
     async def _measure(self):
         # apply state
-        self._pg.set_acquisition_config({"SegmentCount": self._state["segment_count"]})
+        segment_count = self._state["segment_count"]
+        self._pg.set_acquisition_config({"SegmentCount": segment_count})
         self._pg.commit()
         # start capture
         self._pg.start_capture()
@@ -103,9 +104,35 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
             await asyncio.sleep(0)
         self.logger.debug("TIME WAITED", time.time() - before)
         # read out
+        total_size = segment_count * (self._config["depth"] + self._tail_size)
+        temp_segment_size = segment_count * (self._config["segment_size"] + self._tail_size)
+        self._pg.set_acquisition_config(
+            {
+                "Depth" : self.total_size,
+                "SegmentCount": 1,
+                "SegmentSize": temp_segment_size,
+            }
+        )
+        self._pg.commit()
+
         out = {}
         for i in range(0, len(self._config["channels"])):
-            out.update(self._process_single_channel(i))
+            out.update(
+                {
+                    f"ai{i}": process_single_channel(self, i, segment_count, 1, )
+                }
+            )
+            await asyncio.sleep(0)
+
+        self._pg.set_acquisition_config(
+            {
+                "Depth" : self._config["depth"], 
+                "SegmentCount": segment_count, 
+                "SegmentSize": self._config["segment_size"]
+            },
+        )
+        self._pg.commit()
+
         self.logger.debug(out)
         return out
 
@@ -116,7 +143,6 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
         system_info = self._pg.get_system_info()
         channel_info = self._pg.get_channel_config(channel_index + 1)
         for segment in range(self._state["segment_count"]):
-            # TODO: guess transfer mode from if multirecord averaging
             seg = self._pg.transfer_data(
                 channel_index=channel_index + 1,
                 start_position=0,

--- a/yaqd_gage/_compuscope.py
+++ b/yaqd_gage/_compuscope.py
@@ -9,10 +9,7 @@ import numpy as np
 
 from ._constants import acq_status_codes
 from ._pygage import PyGage, uses_pygage, async_uses_pygage
-from ._lib import GaGeSynchronous
-
-impedences = {"fifty": 50, "onemeg": 1_000_000}
-couplings = {"DC": 1, "AC": 2}
+from ._lib import GaGeSynchronous, impedances, couplings, acq_mode
 
 
 class CompuScope(GaGeSynchronous):
@@ -61,7 +58,7 @@ class CompuScope(GaGeSynchronous):
             config = {}
             config["InputRange"] = channel["range"]
             config["Coupling"] = couplings[channel["coupling"]]
-            config["Impedance"] = impedences[channel["impedance"]]
+            config["Impedance"] = impedances[channel["impedance"]]
             config["Filter"] = int(channel["filter"])
             config["DcOffset"] = channel["dc_offset"]
             self._pg.set_channel_config(channel_index + 1, config)
@@ -72,7 +69,7 @@ class CompuScope(GaGeSynchronous):
             config["Level"] = int(trigger["level"])
             config["Source"] = trigger["source"]
             config["ExtRange"] = trigger["range"]
-            config["ExtImpedance"] = impedences[channel["impedance"]]
+            config["ExtImpedance"] = impedances[channel["impedance"]]
             config["ExtCoupling"] = couplings[channel["coupling"]]
             config["Relation"] = 0
             self._pg.set_trigger_config(trigger_index + 1, config)

--- a/yaqd_gage/_compuscope.py
+++ b/yaqd_gage/_compuscope.py
@@ -7,8 +7,8 @@ from typing import Dict
 
 import numpy as np
 
-from ._constants import acq_status_codes, transfer_modes
-from ._pygage import PyGage, uses_pygage, async_uses_pygage, to_voltage
+from ._constants import acq_status_codes
+from ._pygage import PyGage, uses_pygage, async_uses_pygage
 from ._lib import GaGeSynchronous
 
 impedences = {"fifty": 50, "onemeg": 1_000_000}

--- a/yaqd_gage/_compuscope.py
+++ b/yaqd_gage/_compuscope.py
@@ -108,7 +108,7 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
         temp_segment_size = segment_count * (self._config["segment_size"] + self._tail_size)
         self._pg.set_acquisition_config(
             {
-                "Depth" : self.total_size,
+                "Depth": self.total_size,
                 "SegmentCount": 1,
                 "SegmentSize": temp_segment_size,
             }
@@ -119,16 +119,21 @@ class CompuScope(HasMeasureTrigger, IsSensor, IsDaemon):
         for i in range(0, len(self._config["channels"])):
             out.update(
                 {
-                    f"ai{i}": process_single_channel(self, i, segment_count, 1, )
+                    f"ai{i}": process_single_channel(
+                        self,
+                        i,
+                        segment_count,
+                        1,
+                    )
                 }
             )
             await asyncio.sleep(0)
 
         self._pg.set_acquisition_config(
             {
-                "Depth" : self._config["depth"], 
-                "SegmentCount": segment_count, 
-                "SegmentSize": self._config["segment_size"]
+                "Depth": self._config["depth"],
+                "SegmentCount": segment_count,
+                "SegmentSize": self._config["segment_size"],
             },
         )
         self._pg.commit()

--- a/yaqd_gage/_lib.py
+++ b/yaqd_gage/_lib.py
@@ -36,6 +36,9 @@ class GaGeSynchronous(HasMeasureTrigger, IsSensor, IsDaemon):
             system_info["SampleResolution"],
         )
         self.logger.info(segs.shape)
+        # since all segements are now polled simultaneously, 
+        # users only view one sample trace for each measurement
+        self._samples[f"ai{channel_index}"] = segs[-1]
 
         # signal
         channel_config = self._config["channels"][channel_index]
@@ -54,3 +57,15 @@ class GaGeSynchronous(HasMeasureTrigger, IsSensor, IsDaemon):
             signal *= -1
 
         return signal
+
+    def set_segment_count(self, count: int) -> None:
+        self._state["segment_count"] = count
+
+    def close(self):
+        self._pg.free_system()
+
+    def get_segment_count(self) -> int:
+        return self._state["segment_count"]
+
+    def get_segment_count_limits(self) -> list[int]:
+        return [1, self._max_segment_count]

--- a/yaqd_gage/_lib.py
+++ b/yaqd_gage/_lib.py
@@ -49,7 +49,7 @@ class GaGeSynchronous(HasMeasureTrigger, IsSensor, IsDaemon):
         self._pg.commit()
         for i in channel_indices:
             shots = self._process_single_channel(i, segment_count, total_size, record_count)
-            out.update({f"ai{i}": shots})
+            out[f"ai{i}"] = shots
             await asyncio.sleep(0)
         self._pg.set_acquisition_config(
             {
@@ -81,30 +81,27 @@ class GaGeSynchronous(HasMeasureTrigger, IsSensor, IsDaemon):
             segment_index=1,
             transfer_mode=transfer_modes["default"],
         )[0]
-        segs = np.array(segs, dtype=float).reshape(segment_count, -1)
         segs = to_voltage(
-            segs,
+            segs.astype(float),
             record_count,
             system_info["SampleOffset"],
             channel_info["DcOffset"],
             channel_info["InputRange"],
             system_info["SampleResolution"],
-        )
+        ).reshape(segment_count, -1)
+        self._samples[f"ai{channel_index}"] = segs
         self.logger.info(segs.shape)
-        # since all segements are now polled simultaneously,
-        # users only view one sample trace for each measurement
-        self._samples[f"ai{channel_index}"] = segs[-1]
 
         # signal
         channel_config = self._config["channels"][channel_index]
         start = channel_config["signal_start_index"]
         stop = channel_config["signal_stop_index"]
-        signal = segs[start:stop].mean(axis=0)
+        signal = segs[:, start:stop].mean(axis=1)
         # baseline
         if channel_config["use_baseline"]:
             start = channel_config["baseline_start_index"]
             stop = channel_config["baseline_stop_index"]
-            baseline = segs[start:stop].mean(axis=0)
+            baseline = segs[:, start:stop].mean(axis=1)
             signal = signal - baseline
         # invert
         if channel_config["invert"]:

--- a/yaqd_gage/_lib.py
+++ b/yaqd_gage/_lib.py
@@ -10,7 +10,7 @@ from ._pygage import to_voltage
 
 
 class GaGeSynchronous(HasMeasureTrigger, IsSensor, IsDaemon):
-    """parent class for synchronous (non-streaming) acquisitions.  mostly daemons"""
+    """parent class for synchronous (non-streaming) acquisitions"""
 
     async def _capture_and_fetch(
         self,
@@ -43,7 +43,7 @@ class GaGeSynchronous(HasMeasureTrigger, IsSensor, IsDaemon):
         )
         self._pg.commit()
         for i in channel_indices:
-            shots = self._process_single_channel(i, segment_count, record_count, total_size)
+            shots = self._process_single_channel(i, segment_count, total_size, record_count)
             out.update({f"ai{i}": shots})
             await asyncio.sleep(0)
         self._pg.set_acquisition_config(
@@ -63,8 +63,8 @@ class GaGeSynchronous(HasMeasureTrigger, IsSensor, IsDaemon):
         self,
         channel_index: int,
         segment_count: int,
-        record_count: int,
         total_size: int,
+        record_count: int,
     ) -> np.array:
         system_info = self._pg.get_system_info()
         channel_info = self._pg.get_channel_config(channel_index + 1)
@@ -74,7 +74,7 @@ class GaGeSynchronous(HasMeasureTrigger, IsSensor, IsDaemon):
             start_position=0,
             transfer_length=total_size,
             segment_index=1,
-            transfer_mode=transfer_modes["data_32"],
+            transfer_mode=transfer_modes["default"],
         )[0]
         segs = np.array(segs, dtype=float).reshape(segment_count, -1)
         segs = to_voltage(

--- a/yaqd_gage/_lib.py
+++ b/yaqd_gage/_lib.py
@@ -9,6 +9,11 @@ from ._constants import transfer_modes, acq_status_codes
 from ._pygage import to_voltage
 
 
+impedances = {"low": 50, "high": 1_000_000}
+couplings = {"DC": 1, "AC": 2}
+acq_mode = {"quad": 4, "dual": 2, "single": 1}
+
+
 class GaGeSynchronous(HasMeasureTrigger, IsSensor, IsDaemon):
     """parent class for synchronous (non-streaming) acquisitions"""
 

--- a/yaqd_gage/_lib.py
+++ b/yaqd_gage/_lib.py
@@ -1,6 +1,7 @@
 import numpy as np
 import asyncio
 import time
+import json
 
 from yaqd_core import HasMeasureTrigger, IsSensor, IsDaemon
 
@@ -120,3 +121,7 @@ class GaGeSynchronous(HasMeasureTrigger, IsSensor, IsDaemon):
 
     def get_segment_count_limits(self) -> list[int]:
         return [1, self._max_segment_count]
+
+    def get_acq_config(self) -> str:
+        d = self._pg.get_acquisition_config()
+        return json.dumps(d)        

--- a/yaqd_gage/_lib.py
+++ b/yaqd_gage/_lib.py
@@ -28,22 +28,22 @@ class GaGeSynchronous(HasMeasureTrigger, IsSensor, IsDaemon):
 
         t_measured = time.time()
         # read out
-        shots = {}
+        out = {}
         # trick the daq into thinking depth is the total size of the data
         total_size = segment_count * (self._config["depth"] + self._tail_size)
         temp_segment_size = segment_count * (self._config["segment_size"] + self._tail_size)
-        self.logger.debug(f"{self.total_size=}, {self._tail_size=}")
+        self.logger.debug(f"{total_size=}, {self._tail_size=}")
         self._pg.set_acquisition_config(
             {
-                "Depth": self.total_size,
+                "Depth": total_size,
                 "SegmentCount": 1,
                 "SegmentSize": temp_segment_size,
             }
         )
         self._pg.commit()
         for i in channel_indices:
-            shots = self._process_single_channel(self, i, segment_count, record_count, total_size)
-            shots.update({f"ai{i}": shots})
+            shots = self._process_single_channel(i, segment_count, record_count, total_size)
+            out.update({f"ai{i}": shots})
             await asyncio.sleep(0)
         self._pg.set_acquisition_config(
             {
@@ -56,7 +56,7 @@ class GaGeSynchronous(HasMeasureTrigger, IsSensor, IsDaemon):
         t_fetched = time.time()
         self.logger.info(f"measurement: {t_measured-t_start} sec")
         self.logger.info(f"data xt: {t_fetched-t_measured} sec")
-        return shots
+        return out
 
     def _process_single_channel(
         self,

--- a/yaqd_gage/_lib.py
+++ b/yaqd_gage/_lib.py
@@ -1,0 +1,52 @@
+import asyncio
+import numpy as np
+
+from ._constants import transfer_modes
+from ._pygage import to_voltage
+
+
+def _process_single_channel(
+    obj,
+    channel_index: int, 
+    segment_count: int, 
+    record_count: int,
+    total_size: int,
+) -> np.array:
+    system_info = obj._pg.get_system_info()
+    channel_info = obj._pg.get_channel_config(channel_index + 1)
+
+    segs = obj._pg.transfer_data(
+        channel_index=channel_index+1,
+        start_position=0,
+        transfer_length=total_size,
+        segment_index=1,
+        transfer_mode=transfer_modes["data_32"]
+    )[0]
+    segs = np.array(segs, dtype=float).reshape(segment_count, -1)
+    segs = to_voltage(
+            segs,
+            record_count,
+            system_info["SampleOffset"],
+            channel_info["DcOffset"],
+            channel_info["InputRange"],
+            system_info["SampleResolution"],
+    )
+    obj.logger.info(segs.shape)
+
+    # signal
+    channel_config = obj._config["channels"][channel_index]
+    start = channel_config["signal_start_index"]
+    stop = channel_config["signal_stop_index"]
+    signal = segs[start:stop].mean(axis=0)
+    # baseline
+    if channel_config["use_baseline"]:
+        start = channel_config["baseline_start_index"]
+        stop = channel_config["baseline_stop_index"]
+        baseline = segs[start:stop].mean(axis=0)
+        signal = signal - baseline
+
+    # invert
+    if channel_config["invert"]:
+        signal *= -1
+
+    return signal

--- a/yaqd_gage/_lib.py
+++ b/yaqd_gage/_lib.py
@@ -7,12 +7,12 @@ from ._pygage import to_voltage
 
 
 class GaGeSynchronous(HasMeasureTrigger, IsSensor, IsDaemon):
-    """parent class for synchronous (non-streaming) acquisitions.  mostly daemons """
+    """parent class for synchronous (non-streaming) acquisitions.  mostly daemons"""
 
     def _process_single_channel(
         self,
-        channel_index: int, 
-        segment_count: int, 
+        channel_index: int,
+        segment_count: int,
         record_count: int,
         total_size: int,
     ) -> np.array:
@@ -20,20 +20,20 @@ class GaGeSynchronous(HasMeasureTrigger, IsSensor, IsDaemon):
         channel_info = self._pg.get_channel_config(channel_index + 1)
 
         segs = self._pg.transfer_data(
-            channel_index=channel_index+1,
+            channel_index=channel_index + 1,
             start_position=0,
             transfer_length=total_size,
             segment_index=1,
-            transfer_mode=transfer_modes["data_32"]
+            transfer_mode=transfer_modes["data_32"],
         )[0]
         segs = np.array(segs, dtype=float).reshape(segment_count, -1)
         segs = to_voltage(
-                segs,
-                record_count,
-                system_info["SampleOffset"],
-                channel_info["DcOffset"],
-                channel_info["InputRange"],
-                system_info["SampleResolution"],
+            segs,
+            record_count,
+            system_info["SampleOffset"],
+            channel_info["DcOffset"],
+            channel_info["InputRange"],
+            system_info["SampleResolution"],
         )
         self.logger.info(segs.shape)
 

--- a/yaqd_gage/_lib.py
+++ b/yaqd_gage/_lib.py
@@ -13,9 +13,9 @@ class GaGeSynchronous(HasMeasureTrigger, IsSensor, IsDaemon):
 
     async def _capture_and_fetch(
         self,
-        channel_indices:list[int],
-        segment_count:int,
-        record_count:int=1,
+        channel_indices: list[int],
+        segment_count: int,
+        record_count: int = 1,
     ):
         t_start = time.time()
         self._pg.start_capture()
@@ -42,9 +42,7 @@ class GaGeSynchronous(HasMeasureTrigger, IsSensor, IsDaemon):
         )
         self._pg.commit()
         for i in channel_indices:
-            shots = self._process_single_channel(
-                self, i, segment_count, record_count, total_size
-            )
+            shots = self._process_single_channel(self, i, segment_count, record_count, total_size)
             shots.update({f"ai{i}": shots})
             await asyncio.sleep(0)
         self._pg.set_acquisition_config(

--- a/yaqd_gage/_lib.py
+++ b/yaqd_gage/_lib.py
@@ -7,8 +7,8 @@ from ._pygage import to_voltage
 
 def _process_single_channel(
     obj,
-    channel_index: int, 
-    segment_count: int, 
+    channel_index: int,
+    segment_count: int,
     record_count: int,
     total_size: int,
 ) -> np.array:
@@ -16,20 +16,20 @@ def _process_single_channel(
     channel_info = obj._pg.get_channel_config(channel_index + 1)
 
     segs = obj._pg.transfer_data(
-        channel_index=channel_index+1,
+        channel_index=channel_index + 1,
         start_position=0,
         transfer_length=total_size,
         segment_index=1,
-        transfer_mode=transfer_modes["data_32"]
+        transfer_mode=transfer_modes["data_32"],
     )[0]
     segs = np.array(segs, dtype=float).reshape(segment_count, -1)
     segs = to_voltage(
-            segs,
-            record_count,
-            system_info["SampleOffset"],
-            channel_info["DcOffset"],
-            channel_info["InputRange"],
-            system_info["SampleResolution"],
+        segs,
+        record_count,
+        system_info["SampleOffset"],
+        channel_info["DcOffset"],
+        channel_info["InputRange"],
+        system_info["SampleResolution"],
     )
     obj.logger.info(segs.shape)
 

--- a/yaqd_gage/_lib.py
+++ b/yaqd_gage/_lib.py
@@ -124,4 +124,4 @@ class GaGeSynchronous(HasMeasureTrigger, IsSensor, IsDaemon):
 
     def get_acq_config(self) -> str:
         d = self._pg.get_acquisition_config()
-        return json.dumps(d)        
+        return json.dumps(d)

--- a/yaqd_gage/_lib.py
+++ b/yaqd_gage/_lib.py
@@ -61,6 +61,9 @@ class GaGeSynchronous(HasMeasureTrigger, IsSensor, IsDaemon):
     def set_segment_count(self, count: int) -> None:
         self._state["segment_count"] = count
 
+    def get_measured_samples(self):
+        return self._samples
+
     def close(self):
         self._pg.free_system()
 

--- a/yaqd_gage/_lib.py
+++ b/yaqd_gage/_lib.py
@@ -89,7 +89,7 @@ class GaGeSynchronous(HasMeasureTrigger, IsSensor, IsDaemon):
             channel_info["InputRange"],
             system_info["SampleResolution"],
         ).reshape(segment_count, -1)
-        self._samples[f"ai{channel_index}"] = segs
+        self._samples[f"ai{channel_index}"] = segs[-1]
         self.logger.info(segs.shape)
 
         # signal

--- a/yaqd_gage/_lib.py
+++ b/yaqd_gage/_lib.py
@@ -36,7 +36,7 @@ class GaGeSynchronous(HasMeasureTrigger, IsSensor, IsDaemon):
             system_info["SampleResolution"],
         )
         self.logger.info(segs.shape)
-        # since all segements are now polled simultaneously, 
+        # since all segements are now polled simultaneously,
         # users only view one sample trace for each measurement
         self._samples[f"ai{channel_index}"] = segs[-1]
 

--- a/yaqd_gage/_lib.py
+++ b/yaqd_gage/_lib.py
@@ -1,52 +1,56 @@
-import asyncio
 import numpy as np
+
+from yaqd_core import HasMeasureTrigger, IsSensor, IsDaemon
 
 from ._constants import transfer_modes
 from ._pygage import to_voltage
 
 
-def _process_single_channel(
-    obj,
-    channel_index: int,
-    segment_count: int,
-    record_count: int,
-    total_size: int,
-) -> np.array:
-    system_info = obj._pg.get_system_info()
-    channel_info = obj._pg.get_channel_config(channel_index + 1)
+class GaGeSynchronous(HasMeasureTrigger, IsSensor, IsDaemon):
+    """parent class for synchronous (non-streaming) acquisitions.  mostly daemons """
 
-    segs = obj._pg.transfer_data(
-        channel_index=channel_index + 1,
-        start_position=0,
-        transfer_length=total_size,
-        segment_index=1,
-        transfer_mode=transfer_modes["data_32"],
-    )[0]
-    segs = np.array(segs, dtype=float).reshape(segment_count, -1)
-    segs = to_voltage(
-        segs,
-        record_count,
-        system_info["SampleOffset"],
-        channel_info["DcOffset"],
-        channel_info["InputRange"],
-        system_info["SampleResolution"],
-    )
-    obj.logger.info(segs.shape)
+    def _process_single_channel(
+        self,
+        channel_index: int, 
+        segment_count: int, 
+        record_count: int,
+        total_size: int,
+    ) -> np.array:
+        system_info = self._pg.get_system_info()
+        channel_info = self._pg.get_channel_config(channel_index + 1)
 
-    # signal
-    channel_config = obj._config["channels"][channel_index]
-    start = channel_config["signal_start_index"]
-    stop = channel_config["signal_stop_index"]
-    signal = segs[start:stop].mean(axis=0)
-    # baseline
-    if channel_config["use_baseline"]:
-        start = channel_config["baseline_start_index"]
-        stop = channel_config["baseline_stop_index"]
-        baseline = segs[start:stop].mean(axis=0)
-        signal = signal - baseline
+        segs = self._pg.transfer_data(
+            channel_index=channel_index+1,
+            start_position=0,
+            transfer_length=total_size,
+            segment_index=1,
+            transfer_mode=transfer_modes["data_32"]
+        )[0]
+        segs = np.array(segs, dtype=float).reshape(segment_count, -1)
+        segs = to_voltage(
+                segs,
+                record_count,
+                system_info["SampleOffset"],
+                channel_info["DcOffset"],
+                channel_info["InputRange"],
+                system_info["SampleResolution"],
+        )
+        self.logger.info(segs.shape)
 
-    # invert
-    if channel_config["invert"]:
-        signal *= -1
+        # signal
+        channel_config = self._config["channels"][channel_index]
+        start = channel_config["signal_start_index"]
+        stop = channel_config["signal_stop_index"]
+        signal = segs[start:stop].mean(axis=0)
+        # baseline
+        if channel_config["use_baseline"]:
+            start = channel_config["baseline_start_index"]
+            stop = channel_config["baseline_stop_index"]
+            baseline = segs[start:stop].mean(axis=0)
+            signal = signal - baseline
 
-    return signal
+        # invert
+        if channel_config["invert"]:
+            signal *= -1
+
+        return signal

--- a/yaqd_gage/_lib.py
+++ b/yaqd_gage/_lib.py
@@ -13,11 +13,11 @@ class GaGeSynchronous(HasMeasureTrigger, IsSensor, IsDaemon):
 
     async def _capture_and_fetch(
         self,
-        channel_indices: list[int],
-        segment_count,
-        record_count=1,
+        channel_indices:list[int],
+        segment_count:int,
+        record_count:int=1,
     ):
-        before = time.time()
+        t_start = time.time()
         self._pg.start_capture()
         # wait for capture to complete
         while True:
@@ -26,7 +26,7 @@ class GaGeSynchronous(HasMeasureTrigger, IsSensor, IsDaemon):
                 break
             await asyncio.sleep(0)
 
-        finished_measurement = time.time()
+        t_measured = time.time()
         # read out
         shots = {}
         # trick the daq into thinking depth is the total size of the data
@@ -55,9 +55,9 @@ class GaGeSynchronous(HasMeasureTrigger, IsSensor, IsDaemon):
             },
         )
         self._pg.commit()
-        fetched_measurement = time.time()
-        self.logger.info(f"measurement: {finished_measurement-before} sec")
-        self.logger.info(f"data xt: {fetched_measurement-finished_measurement} sec")
+        t_fetched = time.time()
+        self.logger.info(f"measurement: {t_measured-t_start} sec")
+        self.logger.info(f"data xt: {t_fetched-t_measured} sec")
         return shots
 
     def _process_single_channel(
@@ -102,7 +102,6 @@ class GaGeSynchronous(HasMeasureTrigger, IsSensor, IsDaemon):
             stop = channel_config["baseline_stop_index"]
             baseline = segs[start:stop].mean(axis=0)
             signal = signal - baseline
-
         # invert
         if channel_config["invert"]:
             signal *= -1

--- a/yaqd_gage/_lib.py
+++ b/yaqd_gage/_lib.py
@@ -1,13 +1,64 @@
 import numpy as np
+import asyncio
+import time
 
 from yaqd_core import HasMeasureTrigger, IsSensor, IsDaemon
 
-from ._constants import transfer_modes
+from ._constants import transfer_modes, acq_status_codes
 from ._pygage import to_voltage
 
 
 class GaGeSynchronous(HasMeasureTrigger, IsSensor, IsDaemon):
     """parent class for synchronous (non-streaming) acquisitions.  mostly daemons"""
+
+    async def _capture_and_fetch(
+        self,
+        channel_indices: list[int],
+        segment_count,
+        record_count=1,
+    ):
+        before = time.time()
+        self._pg.start_capture()
+        # wait for capture to complete
+        while True:
+            code = self._pg.get_status()
+            if acq_status_codes[code] == "ACQ_STATUS_READY":
+                break
+            await asyncio.sleep(0)
+
+        finished_measurement = time.time()
+        # read out
+        shots = {}
+        # trick the daq into thinking depth is the total size of the data
+        total_size = segment_count * (self._config["depth"] + self._tail_size)
+        temp_segment_size = segment_count * (self._config["segment_size"] + self._tail_size)
+        self.logger.debug(f"{self.total_size=}, {self._tail_size=}")
+        self._pg.set_acquisition_config(
+            {
+                "Depth": self.total_size,
+                "SegmentCount": 1,
+                "SegmentSize": temp_segment_size,
+            }
+        )
+        self._pg.commit()
+        for i in channel_indices:
+            shots = self._process_single_channel(
+                self, i, segment_count, record_count, total_size
+            )
+            shots.update({f"ai{i}": shots})
+            await asyncio.sleep(0)
+        self._pg.set_acquisition_config(
+            {
+                "Depth": self._config["depth"],
+                "SegmentCount": segment_count,
+                "SegmentSize": self._config["segment_size"],
+            },
+        )
+        self._pg.commit()
+        fetched_measurement = time.time()
+        self.logger.info(f"measurement: {finished_measurement-before} sec")
+        self.logger.info(f"data xt: {fetched_measurement-finished_measurement} sec")
+        return shots
 
     def _process_single_channel(
         self,

--- a/yaqd_gage/_pygage.py
+++ b/yaqd_gage/_pygage.py
@@ -107,7 +107,7 @@ class PyGage(object):
     @compuscope_error_handling
     def get_segment_tail_size(self):
         return self.interface.GetSegmentTailSizeInBytes(self.handle)
-        
+
     @compuscope_error_handling
     def get_status(self):
         return self.interface.GetStatus(self.handle)

--- a/yaqd_gage/_pygage.py
+++ b/yaqd_gage/_pygage.py
@@ -118,10 +118,11 @@ class PyGage(object):
         return self.interface.GetTriggerConfig(self.handle, trigger_index)
 
     @compuscope_error_handling
-    def get_system(self):
-        # I don't understand what the arguments to this function
-        # (the four zeros) do. It's working for me right now.
-        # - Blaise 2020-01-09
+    def get_system(self, board_type=0, channels=0, sample_bits=0, index=0):
+        """
+        select a specific board from the system
+        default arguments find the first available gage board
+        """
         handle = self.interface.GetSystem(0, 0, 0, 0)
         return handle
 

--- a/yaqd_gage/_pygage.py
+++ b/yaqd_gage/_pygage.py
@@ -105,8 +105,16 @@ class PyGage(object):
         return self.interface.GetMulRecAverageCount(self.handle)
 
     @compuscope_error_handling
+    def get_segment_tail_size(self):
+        return self.interface.GetSegmentTailSizeInBytes(self.handle)
+        
+    @compuscope_error_handling
     def get_status(self):
         return self.interface.GetStatus(self.handle)
+
+    @compuscope_error_handling
+    def get_system_caps(self, key):
+        return self.interface.GetSystemCaps(self.handle, key)
 
     @compuscope_error_handling
     def get_trigger_config(self, trigger_index):

--- a/yaqd_gage/_pygage.py
+++ b/yaqd_gage/_pygage.py
@@ -1,10 +1,7 @@
 """Wrapper to normalize PyGage support."""
 
 import sys
-import time
 from functools import wraps
-
-import numpy as np  # type: ignore
 
 from ._exceptions import CompuScopeException
 from ._constants import transfer_modes

--- a/yaqd_gage/gage-chopping.avpr
+++ b/yaqd_gage/gage-chopping.avpr
@@ -479,11 +479,12 @@
                     "type": "int"
                 },
                 {
+                    "doc": "AC or DC input coupling",
                     "name": "coupling",
                     "type": "coupling_mode"
                 },
                 {
-                    "doc": "low (50 ohms) or high (1 MegaOhm)",
+                    "doc": "low or high input impedance setting",
                     "name": "impedance",
                     "type": "impedance_mode"
                 },
@@ -587,10 +588,12 @@
                     "type": "int"
                 },
                 {
+                    "doc": "AC or DC input coupling",
                     "name": "coupling",
                     "type": "coupling_mode"
                 },
                 {
+                    "doc": "low or high input impedance setting",
                     "name": "impedance",
                     "type": "impedance_mode"
                 }

--- a/yaqd_gage/gage-chopping.avpr
+++ b/yaqd_gage/gage-chopping.avpr
@@ -9,7 +9,7 @@
         },
         "chop_channel": {
             "default": 1,
-            "doc": "Set which channel is the chop indicator.",
+            "doc": "Set the chopping channel. Defaults to 1.",
             "type": "int"
         },
         "depth": {
@@ -69,7 +69,7 @@
         },
         "mode": {
             "default": "quad",
-            "doc": "Set how many channels will be active on board.",
+            "doc": "Set how many on-board channels will be active.",
             "type": "acquisition_mode"
         },
         "model": {
@@ -114,10 +114,15 @@
                 "string"
             ]
         },
-        "signal_channel": {
-            "default": 0,
-            "doc": "Set the signal channel. Defaults to 0.",
-            "type": "int"
+        "signal_channels": {
+            "default": [
+                0
+            ],
+            "doc": "A list of raw channel indices that are measured.",
+            "type": {
+                "items": "int",
+                "type": "array"
+            }
         },
         "time_stamp_clock": {
             "default": "Fixed",
@@ -463,11 +468,11 @@
             "type": "enum"
         },
         {
-            "default": "fifty",
+            "default": "low",
             "name": "impedance_mode",
             "symbols": [
-                "fifty",
-                "onemeg"
+                "low",
+                "high"
             ],
             "type": "enum"
         },
@@ -483,6 +488,7 @@
                     "type": "coupling_mode"
                 },
                 {
+                    "doc": "low (50 ohms) or high (1 MegaOhm)",
                     "name": "impedance",
                     "type": "impedance_mode"
                 },

--- a/yaqd_gage/gage-chopping.avpr
+++ b/yaqd_gage/gage-chopping.avpr
@@ -165,6 +165,10 @@
             "request": [],
             "response": "boolean"
         },
+        "get_acq_config": {
+            "request": [],
+            "response": "string"
+        },
         "get_channel_names": {
             "doc": "Get current channel names.",
             "origin": "is-sensor",

--- a/yaqd_gage/gage-chopping.avpr
+++ b/yaqd_gage/gage-chopping.avpr
@@ -229,7 +229,7 @@
             }
         },
         "get_measured_samples": {
-            "doc": "Get a dictionary of 1D arrays of measured samples.",
+            "doc": "Get the scope traces of a single segment.",
             "request": [],
             "response": {
                 "type": "map",
@@ -237,7 +237,7 @@
             }
         },
         "get_measured_segments": {
-            "doc": "Get a dictionary of 1D arrays of measured segments.",
+            "doc": "Get all measured segments in a measurement.",
             "request": [],
             "response": {
                 "type": "map",

--- a/yaqd_gage/gage-chopping.avpr
+++ b/yaqd_gage/gage-chopping.avpr
@@ -5,9 +5,14 @@
             "items": "channel",
             "type": "array"
         },
+        "chop_channel": {
+            "default": 1,
+            "doc": "Set which channel is the chop indicator.",
+            "type": "int"
+        },
         "depth": {
             "default": 240,
-            "doc": "Post-trigger depth, in samples.",
+            "doc": "Post-trigger depth, in samples.  Numbers must be divisible by 16/[number of channels].",
             "type": "int"
         },
         "enable": {
@@ -62,7 +67,7 @@
         },
         "mode": {
             "default": "quad",
-            "doc": "Set how many channels will be used.",
+            "doc": "Set how many channels will be active on board.",
             "type": "acquisition_mode"
         },
         "model": {
@@ -105,6 +110,11 @@
                 "string"
             ]
         },
+        "signal_channel": {
+            "default": 0,
+            "doc": "Set the signal channel. Defaults to 0.",
+            "type": "int"
+        },
         "time_stamp_clock": {
             "default": "Fixed",
             "doc": "The time-stamping clock may operate in one of two modes. In fixed mode, the on-board oscillator will be used as the counter source. In sample mode, a frequency derived from the sampling clock will be used as the counter source.",
@@ -136,7 +146,7 @@
             "type": "int"
         },
         "trigger_time_out": {
-            "default": 1000000,
+            "default": -1,
             "doc": "Trigger timeout of the CompuScope system. The value is in 100 nanosecond units of time (e.g. a value of 10,000,000 gives a trigger timeout of 1 second). A value of -1 will cause the driver to wait indefinitely for a trigger.",
             "type": "int"
         },

--- a/yaqd_gage/gage-chopping.avpr
+++ b/yaqd_gage/gage-chopping.avpr
@@ -61,9 +61,9 @@
             ]
         },
         "mode": {
-            "default": 1073741828,
-            "doc": "Sets the operating mode of the CompuScope system. Refer to the CompuScope documentation for valid values. Default is 1073741828 for FirmWare Averaging and four channels.",
-            "type": "int"
+            "default": "quad",
+            "doc": "Set how many channels will be used.",
+            "type": "acquisition_mode"
         },
         "model": {
             "default": null,
@@ -266,11 +266,6 @@
             "request": [],
             "response": "string"
         },
-        "get_record_count": {
-            "doc": "Get the number of acquisitions that are averaged on-board via firmware.",
-            "request": [],
-            "response": "int"
-        },
         "get_segment_count": {
             "doc": "Get the currently planned number of chunks.",
             "request": [],
@@ -334,16 +329,6 @@
             ],
             "response": "null"
         },
-        "set_record_count": {
-            "doc": "Set record count.",
-            "request": [
-                {
-                    "name": "count",
-                    "type": "int"
-                }
-            ],
-            "response": "null"
-        },
         "set_segment_count": {
             "doc": "Set the chunk count.",
             "request": [
@@ -396,17 +381,6 @@
             "type": "float",
             "units_getter": "get_photon_threshold_units"
         },
-        "record_count": {
-            "control_kind": "hinted",
-            "dynamic": true,
-            "getter": "get_record_count",
-            "limits_getter": null,
-            "options_getter": null,
-            "record_kind": "metadata",
-            "setter": "set_record_count",
-            "type": "int",
-            "units_getter": null
-        },
         "segment_count": {
             "control_kind": "hinted",
             "dynamic": true,
@@ -450,6 +424,16 @@
     ],
     "types": [
         {
+            "default": "quad",
+            "name": "acquisition_mode",
+            "symbols": [
+                "quad",
+                "dual",
+                "single"
+            ],
+            "type": "enum"
+        },
+        {
             "default": "DC",
             "name": "coupling_mode",
             "symbols": [
@@ -481,18 +465,6 @@
                 {
                     "name": "impedance",
                     "type": "impedance_mode"
-                },
-                {
-                    "default": false,
-                    "doc": "Enable differential input coupling. Not all CompuScope models support differential input coupling.",
-                    "name": "diff_input",
-                    "type": "boolean"
-                },
-                {
-                    "default": false,
-                    "doc": "Enable direct-to-ADC input coupling. Not all CompuScope models support direct-to-ADC input coupling.",
-                    "name": "direct_adc",
-                    "type": "boolean"
                 },
                 {
                     "default": false,

--- a/yaqd_gage/gage-chopping.avpr
+++ b/yaqd_gage/gage-chopping.avpr
@@ -496,25 +496,37 @@
                     "default": false,
                     "doc": "Enable low-pass filtering. Not all CopuScope models support low-pass filtering.",
                     "name": "filter",
-                    "type": "boolean"
+                    "type": [
+                        "null",
+                        "boolean"
+                    ]
                 },
                 {
                     "default": 0,
                     "doc": "DC offset for this channel in millivolts. Can be negative or positive.",
                     "name": "dc_offset",
-                    "type": "int"
+                    "type": [
+                        "null",
+                        "int"
+                    ]
                 },
                 {
                     "default": 0,
                     "doc": "Start index for signal region in post-processing. NumPy style indexing.",
                     "name": "signal_start_index",
-                    "type": "int"
+                    "type": [
+                        "null",
+                        "int"
+                    ]
                 },
                 {
                     "default": -1,
                     "doc": "Stop index for signal region in post-processing. Numpy style indexing.",
                     "name": "signal_stop_index",
-                    "type": "int"
+                    "type": [
+                        "null",
+                        "int"
+                    ]
                 },
                 {
                     "default": null,
@@ -538,13 +550,19 @@
                     "default": false,
                     "doc": "Enable baseline subtraction for post-processing.",
                     "name": "use_baseline",
-                    "type": "boolean"
+                    "type": [
+                        "null",
+                        "boolean"
+                    ]
                 },
                 {
                     "default": false,
                     "doc": "If true, post-processed signal is inverted.",
                     "name": "invert",
-                    "type": "boolean"
+                    "type": [
+                        "null",
+                        "boolean"
+                    ]
                 }
             ],
             "name": "channel",

--- a/yaqd_gage/gage-chopping.avpr
+++ b/yaqd_gage/gage-chopping.avpr
@@ -431,11 +431,6 @@
             "doc": "Voltage at which photon events are counted.",
             "type": "float"
         },
-        "record_count": {
-            "default": 32,
-            "doc": "Number of shots to collect and firmware-average.",
-            "type": "int"
-        },
         "segment_count": {
             "default": 1000,
             "doc": "Number of times to acquire record_count.",

--- a/yaqd_gage/gage-chopping.toml
+++ b/yaqd_gage/gage-chopping.toml
@@ -39,14 +39,14 @@ fields = [
 	{"name"="range", "type"="int", "doc"="Full input range in millivolts."},
 	{"name"="coupling", "type"="coupling_mode"},
 	{"name"="impedance", "type"="impedance_mode", "doc"="low (50 ohms) or high (1 MegaOhm)"},
-	{"name"="filter", "type"="boolean", "default"=false, "doc"="Enable low-pass filtering. Not all CopuScope models support low-pass filtering."},
-	{"name"="dc_offset", "type"="int", "default"=0, "doc"="DC offset for this channel in millivolts. Can be negative or positive."},
-	{"name"="signal_start_index", "type"="int", "default"=0, "doc"="Start index for signal region in post-processing. NumPy style indexing."},
-	{"name"="signal_stop_index", "type"="int", "default"=-1, "doc"="Stop index for signal region in post-processing. Numpy style indexing."},
+	{"name"="filter", "type"=["null", "boolean"], "default"=false, "doc"="Enable low-pass filtering. Not all CopuScope models support low-pass filtering."},
+	{"name"="dc_offset", "type"=["null", "int"], "default"=0, "doc"="DC offset for this channel in millivolts. Can be negative or positive."},
+	{"name"="signal_start_index", "type"=["null", "int"], "default"=0, "doc"="Start index for signal region in post-processing. NumPy style indexing."},
+	{"name"="signal_stop_index", "type"=["null", "int"], "default"=-1, "doc"="Stop index for signal region in post-processing. Numpy style indexing."},
 	{"name"="baseline_start_index", "type"=["null", "int"], "default"="__null__", "doc"="Start index for baseline region in post-processing. NumPy style indexing."},
 	{"name"="baseline_stop_index", "type"=["null", "int"], "default"="__null__", "doc"="Stop index for baseline region in post-processing. Numpy style indexing."},
-	{"name"="use_baseline", "type"="boolean", "default"=false, "doc"="Enable baseline subtraction for post-processing."},
-	{"name"="invert", "type"="boolean", "default"=false, "doc"="If true, post-processed signal is inverted."},
+	{"name"="use_baseline", "type"=["null", "boolean"], "default"=false, "doc"="Enable baseline subtraction for post-processing."},
+	{"name"="invert", "type"=["null", "boolean"], "default"=false, "doc"="If true, post-processed signal is inverted."},
 ]
 
 [[types]]

--- a/yaqd_gage/gage-chopping.toml
+++ b/yaqd_gage/gage-chopping.toml
@@ -37,8 +37,8 @@ type = "record"
 name = "channel"
 fields = [
 	{"name"="range", "type"="int", "doc"="Full input range in millivolts."},
-	{"name"="coupling", "type"="coupling_mode"},
-	{"name"="impedance", "type"="impedance_mode", "doc"="low (50 ohms) or high (1 MegaOhm)"},
+	{"name"="coupling", "type"="coupling_mode", "doc"="AC or DC input coupling"},
+	{"name"="impedance", "type"="impedance_mode", "doc"="low or high input impedance setting"},
 	{"name"="filter", "type"=["null", "boolean"], "default"=false, "doc"="Enable low-pass filtering. Not all CopuScope models support low-pass filtering."},
 	{"name"="dc_offset", "type"=["null", "int"], "default"=0, "doc"="DC offset for this channel in millivolts. Can be negative or positive."},
 	{"name"="signal_start_index", "type"=["null", "int"], "default"=0, "doc"="Start index for signal region in post-processing. NumPy style indexing."},
@@ -57,8 +57,8 @@ fields = [
 	{"name"="condition", "type"="int", "doc"="Trigger condition. Refer to the CompuScope documentation for valid values."},
 	{"name"="level", "type"="int", "default"=0, "doc"="Trigger level as a perentage of the input range of the trigger source (half the full scale input range). For example, in the 2000 mV range at 0 DC offset, 50 would be positive 50% of 1 Volt, or 500 millivolts."},
 	{"name"="source", "type"="int", "doc"="Trigger source. Refer to the CompuScope documentation for valid values."},
-	{"name"="coupling", "type"="coupling_mode"},
-	{"name"="impedance", "type"="impedance_mode"}
+	{"name"="coupling", "type"="coupling_mode", "doc"="AC or DC input coupling"},
+	{"name"="impedance", "type"="impedance_mode", "doc"="low or high input impedance setting"},
 ]
 
 [[types]]

--- a/yaqd_gage/gage-chopping.toml
+++ b/yaqd_gage/gage-chopping.toml
@@ -16,6 +16,12 @@ PyPI = "https://pypi.org/project/yaqd-gage"
 
 [[types]]
 type = "enum"
+name = "acquisition_mode"
+symbols = ["quad", "dual", "single"]
+default = "quad"
+
+[[types]]
+type = "enum"
 name = "coupling_mode"
 symbols = ["AC", "DC"]
 default = "DC"
@@ -29,19 +35,19 @@ default = "fifty"
 [[types]]
 type = "record"
 name = "channel"
-fields = [{"name"="range", "type"="int", "doc"="Full input range in millivolts."},
-          {"name"="coupling", "type"="coupling_mode"},
-	  {"name"="impedance", "type"="impedance_mode"},
-	  {"name"="diff_input", "type"="boolean", "default"=false, "doc"="Enable differential input coupling. Not all CompuScope models support differential input coupling."},
-	  {"name"="direct_adc", "type"="boolean", "default"=false, "doc"="Enable direct-to-ADC input coupling. Not all CompuScope models support direct-to-ADC input coupling."},
-	  {"name"="filter", "type"="boolean", "default"=false, "doc"="Enable low-pass filtering. Not all CopuScope models support low-pass filtering."},
-	  {"name"="dc_offset", "type"="int", "default"=0, "doc"="DC offset for this channel in millivolts. Can be negative or positive."},
-	  {"name"="signal_start_index", "type"="int", "default"=0, "doc"="Start index for signal region in post-processing. NumPy style indexing."},
-	  {"name"="signal_stop_index", "type"="int", "default"=-1, "doc"="Stop index for signal region in post-processing. Numpy style indexing."},
-	  {"name"="baseline_start_index", "type"=["null", "int"], "default"="__null__", "doc"="Start index for baseline region in post-processing. NumPy style indexing."},
-	  {"name"="baseline_stop_index", "type"=["null", "int"], "default"="__null__", "doc"="Stop index for baseline region in post-processing. Numpy style indexing."},
-	  {"name"="use_baseline", "type"="boolean", "default"=false, "doc"="Enable baseline subtraction for post-processing."},
-	  {"name"="invert", "type"="boolean", "default"=false, "doc"="If true, post-processed signal is inverted."}]
+fields = [
+	{"name"="range", "type"="int", "doc"="Full input range in millivolts."},
+	{"name"="coupling", "type"="coupling_mode"},
+	{"name"="impedance", "type"="impedance_mode"},
+	{"name"="filter", "type"="boolean", "default"=false, "doc"="Enable low-pass filtering. Not all CopuScope models support low-pass filtering."},
+	{"name"="dc_offset", "type"="int", "default"=0, "doc"="DC offset for this channel in millivolts. Can be negative or positive."},
+	{"name"="signal_start_index", "type"="int", "default"=0, "doc"="Start index for signal region in post-processing. NumPy style indexing."},
+	{"name"="signal_stop_index", "type"="int", "default"=-1, "doc"="Stop index for signal region in post-processing. Numpy style indexing."},
+	{"name"="baseline_start_index", "type"=["null", "int"], "default"="__null__", "doc"="Start index for baseline region in post-processing. NumPy style indexing."},
+	{"name"="baseline_stop_index", "type"=["null", "int"], "default"="__null__", "doc"="Stop index for baseline region in post-processing. Numpy style indexing."},
+	{"name"="use_baseline", "type"="boolean", "default"=false, "doc"="Enable baseline subtraction for post-processing."},
+	{"name"="invert", "type"="boolean", "default"=false, "doc"="If true, post-processed signal is inverted."}
+]
 
 [[types]]
 type = "record"
@@ -62,9 +68,9 @@ fields = [{"name"="min", "type"="double"},
 [config]
 
 [config.mode]
-doc = "Sets the operating mode of the CompuScope system. Refer to the CompuScope documentation for valid values. Default is 1073741828 for FirmWare Averaging and four channels."
-type = "int"
-default = 0x40000004
+doc = "Set how many channels will be used."
+type = "acquisition_mode"
+default = "quad"
 
 [config.sample_rate]
 doc = "Sampling rate in Hertz. If not provided, model-dependent default is used."
@@ -166,10 +172,6 @@ response = {"type"="map", "values"="ndarray"}
 doc = "Get all measured segments in a measurement."
 response = {"type"="map", "values"="ndarray"}
 
-[messages.get_record_count]
-doc = "Get the number of acquisitions that are averaged on-board via firmware."
-response = "int"
-
 [messages.get_segment_count]
 doc = "Get the currently planned number of chunks."
 response = "int"
@@ -184,10 +186,6 @@ request = [{"name"="count", "type"="int"}]
 
 [messages.set_segment_count]
 doc = "Set the chunk count."
-request = [{"name"="count", "type"="int"}]
-
-[messages.set_record_count]
-doc = "Set record count."
 request = [{"name"="count", "type"="int"}]
 
 [messages.get_photon_threshold]
@@ -212,13 +210,6 @@ getter = "get_edge_width_count"
 setter = "set_edge_width_count"
 type = "int"
 control_kind = "normal"
-record_kind = "metadata"
-
-[properties.record_count]
-getter = "get_record_count"
-setter = "set_record_count"
-type = "int"
-control_kind = "hinted"
 record_kind = "metadata"
 
 [properties.segment_count]

--- a/yaqd_gage/gage-chopping.toml
+++ b/yaqd_gage/gage-chopping.toml
@@ -52,12 +52,14 @@ fields = [
 [[types]]
 type = "record"
 name = "trigger"
-fields = [{"name"="range", "type"="int", "doc"="Full input range in millivolts."},
-          {"name"="condition", "type"="int", "doc"="Trigger condition. Refer to the CompuScope documentation for valid values."},
-          {"name"="level", "type"="int", "default"=0, "doc"="Trigger level as a perentage of the input range of the trigger source (half the full scale input range). For example, in the 2000 mV range at 0 DC offset, 50 would be positive 50% of 1 Volt, or 500 millivolts."},
-	  {"name"="source", "type"="int", "doc"="Trigger source. Refer to the CompuScope documentation for valid values."},
-	  {"name"="coupling", "type"="coupling_mode"},
-	  {"name"="impedance", "type"="impedance_mode"}]
+fields = [
+	{"name"="range", "type"="int", "doc"="Full input range in millivolts."},
+	{"name"="condition", "type"="int", "doc"="Trigger condition. Refer to the CompuScope documentation for valid values."},
+	{"name"="level", "type"="int", "default"=0, "doc"="Trigger level as a perentage of the input range of the trigger source (half the full scale input range). For example, in the 2000 mV range at 0 DC offset, 50 would be positive 50% of 1 Volt, or 500 millivolts."},
+	{"name"="source", "type"="int", "doc"="Trigger source. Refer to the CompuScope documentation for valid values."},
+	{"name"="coupling", "type"="coupling_mode"},
+	{"name"="impedance", "type"="impedance_mode"}
+]
 
 [[types]]
 type = "record"
@@ -68,9 +70,19 @@ fields = [{"name"="min", "type"="double"},
 [config]
 
 [config.mode]
-doc = "Set how many channels will be used."
+doc = "Set how many channels will be active on board."
 type = "acquisition_mode"
 default = "quad"
+
+[config.chop_channel]
+doc = "Set which channel is the chop indicator."
+type = "int"
+default = 1
+
+[config.signal_channel]
+doc = "Set the signal channel. Defaults to 0."
+type = "int"
+default = 0
 
 [config.sample_rate]
 doc = "Sampling rate in Hertz. If not provided, model-dependent default is used."
@@ -78,7 +90,7 @@ type = ["null", "int"]
 default = "__null__"
 
 [config.depth]
-doc = "Post-trigger depth, in samples."
+doc = "Post-trigger depth, in samples.  Numbers must be divisible by 16/[number of channels]."
 type = "int"
 default = 240
 
@@ -95,7 +107,7 @@ default = 0
 [config.trigger_time_out]
 doc = "Trigger timeout of the CompuScope system. The value is in 100 nanosecond units of time (e.g. a value of 10,000,000 gives a trigger timeout of 1 second). A value of -1 will cause the driver to wait indefinitely for a trigger."
 type = "int"
-default = 1000000
+default = -1
 
 [config.trigger_hold_off]
 doc = "Number of samples during which trigger events will be ignored after the system begins capturing. This is useful for ensuring the accumulation of a specified amount of pre-trigger data."

--- a/yaqd_gage/gage-chopping.toml
+++ b/yaqd_gage/gage-chopping.toml
@@ -29,8 +29,8 @@ default = "DC"
 [[types]]
 type = "enum"
 name = "impedance_mode"
-symbols = ["fifty", "onemeg"]
-default = "fifty"
+symbols = ["low", "high"]
+default = "low"
 
 [[types]]
 type = "record"
@@ -38,7 +38,7 @@ name = "channel"
 fields = [
 	{"name"="range", "type"="int", "doc"="Full input range in millivolts."},
 	{"name"="coupling", "type"="coupling_mode"},
-	{"name"="impedance", "type"="impedance_mode"},
+	{"name"="impedance", "type"="impedance_mode", "doc"="low (50 ohms) or high (1 MegaOhm)"},
 	{"name"="filter", "type"="boolean", "default"=false, "doc"="Enable low-pass filtering. Not all CopuScope models support low-pass filtering."},
 	{"name"="dc_offset", "type"="int", "default"=0, "doc"="DC offset for this channel in millivolts. Can be negative or positive."},
 	{"name"="signal_start_index", "type"="int", "default"=0, "doc"="Start index for signal region in post-processing. NumPy style indexing."},
@@ -46,7 +46,7 @@ fields = [
 	{"name"="baseline_start_index", "type"=["null", "int"], "default"="__null__", "doc"="Start index for baseline region in post-processing. NumPy style indexing."},
 	{"name"="baseline_stop_index", "type"=["null", "int"], "default"="__null__", "doc"="Stop index for baseline region in post-processing. Numpy style indexing."},
 	{"name"="use_baseline", "type"="boolean", "default"=false, "doc"="Enable baseline subtraction for post-processing."},
-	{"name"="invert", "type"="boolean", "default"=false, "doc"="If true, post-processed signal is inverted."}
+	{"name"="invert", "type"="boolean", "default"=false, "doc"="If true, post-processed signal is inverted."},
 ]
 
 [[types]]
@@ -70,19 +70,19 @@ fields = [{"name"="min", "type"="double"},
 [config]
 
 [config.mode]
-doc = "Set how many channels will be active on board."
+doc = "Set how many on-board channels will be active."
 type = "acquisition_mode"
 default = "quad"
 
 [config.chop_channel]
-doc = "Set which channel is the chop indicator."
+doc = "Set the chopping channel. Defaults to 1."
 type = "int"
 default = 1
 
-[config.signal_channel]
-doc = "Set the signal channel. Defaults to 0."
-type = "int"
-default = 0
+[config.signal_channels]
+doc = "A list of raw channel indices that are measured."
+type = {"type"="array", "items"="int"}
+default = [0]
 
 [config.sample_rate]
 doc = "Sampling rate in Hertz. If not provided, model-dependent default is used."

--- a/yaqd_gage/gage-chopping.toml
+++ b/yaqd_gage/gage-chopping.toml
@@ -159,11 +159,11 @@ doc = "Get edge width count."
 response = "int"
 
 [messages.get_measured_samples]
-doc = "Get a dictionary of 1D arrays of measured samples."
+doc = "Get the scope traces of a single segment."
 response = {"type"="map", "values"="ndarray"}
 
 [messages.get_measured_segments]
-doc = "Get a dictionary of 1D arrays of measured segments."
+doc = "Get all measured segments in a measurement."
 response = {"type"="map", "values"="ndarray"}
 
 [messages.get_record_count]

--- a/yaqd_gage/gage-chopping.toml
+++ b/yaqd_gage/gage-chopping.toml
@@ -143,11 +143,6 @@ default = {}
 
 [state]
 
-[state.record_count]
-doc = "Number of shots to collect and firmware-average."
-type = "int"
-default = 32
-
 [state.segment_count]
 doc = "Number of times to acquire record_count."
 type = "int"

--- a/yaqd_gage/gage-chopping.toml
+++ b/yaqd_gage/gage-chopping.toml
@@ -202,6 +202,8 @@ request = [{"name"="threshold", "type"="float"}]
 doc = ""
 response = "string"
 
+[messages.get_acq_config]
+response = "string"
 
 [properties]
 

--- a/yaqd_gage/gage-chopping_config.json
+++ b/yaqd_gage/gage-chopping_config.json
@@ -16,7 +16,7 @@
             },
             "chop_channel": {
                 "default": 1,
-                "description": "Set which channel is the chop indicator.",
+                "description": "Set the chopping channel. Defaults to 1.",
                 "format": "int32",
                 "type": [
                     "integer",
@@ -92,7 +92,7 @@
             },
             "mode": {
                 "default": "quad",
-                "description": "Set how many channels will be active on board.",
+                "description": "Set how many on-board channels will be active.",
                 "enum": [
                     "quad",
                     "dual",
@@ -152,12 +152,17 @@
                     "null"
                 ]
             },
-            "signal_channel": {
-                "default": 0,
-                "description": "Set the signal channel. Defaults to 0.",
-                "format": "int32",
+            "signal_channels": {
+                "default": [
+                    0
+                ],
+                "description": "A list of raw channel indices that are measured.",
+                "items": {
+                    "format": "int32",
+                    "type": "integer"
+                },
                 "type": [
-                    "integer",
+                    "array",
                     "null"
                 ]
             },
@@ -264,9 +269,10 @@
                     "type": "boolean"
                 },
                 "impedance": {
+                    "description": "low (50 ohms) or high (1 MegaOhm)",
                     "enum": [
-                        "fifty",
-                        "onemeg"
+                        "low",
+                        "high"
                     ],
                     "title": "impedance_mode",
                     "type": "string"
@@ -326,8 +332,8 @@
                 },
                 "impedance": {
                     "enum": [
-                        "fifty",
-                        "onemeg"
+                        "low",
+                        "high"
                     ],
                     "title": "impedance_mode",
                     "type": "string"
@@ -394,7 +400,7 @@
                 },
                 "chop_channel": {
                     "default": 1,
-                    "description": "Set which channel is the chop indicator.",
+                    "description": "Set the chopping channel. Defaults to 1.",
                     "format": "int32",
                     "type": [
                         "integer",
@@ -470,7 +476,7 @@
                 },
                 "mode": {
                     "default": "quad",
-                    "description": "Set how many channels will be active on board.",
+                    "description": "Set how many on-board channels will be active.",
                     "enum": [
                         "quad",
                         "dual",
@@ -530,12 +536,17 @@
                         "null"
                     ]
                 },
-                "signal_channel": {
-                    "default": 0,
-                    "description": "Set the signal channel. Defaults to 0.",
-                    "format": "int32",
+                "signal_channels": {
+                    "default": [
+                        0
+                    ],
+                    "description": "A list of raw channel indices that are measured.",
+                    "items": {
+                        "format": "int32",
+                        "type": "integer"
+                    },
                     "type": [
-                        "integer",
+                        "array",
                         "null"
                     ]
                 },

--- a/yaqd_gage/gage-chopping_config.json
+++ b/yaqd_gage/gage-chopping_config.json
@@ -252,6 +252,7 @@
                     ]
                 },
                 "coupling": {
+                    "description": "AC or DC input coupling",
                     "enum": [
                         "AC",
                         "DC"
@@ -275,7 +276,7 @@
                     ]
                 },
                 "impedance": {
-                    "description": "low (50 ohms) or high (1 MegaOhm)",
+                    "description": "low or high input impedance setting",
                     "enum": [
                         "low",
                         "high"
@@ -335,6 +336,7 @@
                     "type": "integer"
                 },
                 "coupling": {
+                    "description": "AC or DC input coupling",
                     "enum": [
                         "AC",
                         "DC"
@@ -343,6 +345,7 @@
                     "type": "string"
                 },
                 "impedance": {
+                    "description": "low or high input impedance setting",
                     "enum": [
                         "low",
                         "high"

--- a/yaqd_gage/gage-chopping_config.json
+++ b/yaqd_gage/gage-chopping_config.json
@@ -262,11 +262,17 @@
                 "dc_offset": {
                     "description": "DC offset for this channel in millivolts. Can be negative or positive.",
                     "format": "int32",
-                    "type": "integer"
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
                 },
                 "filter": {
                     "description": "Enable low-pass filtering. Not all CopuScope models support low-pass filtering.",
-                    "type": "boolean"
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
                 },
                 "impedance": {
                     "description": "low (50 ohms) or high (1 MegaOhm)",
@@ -279,7 +285,10 @@
                 },
                 "invert": {
                     "description": "If true, post-processed signal is inverted.",
-                    "type": "boolean"
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
                 },
                 "range": {
                     "description": "Full input range in millivolts.",
@@ -289,28 +298,31 @@
                 "signal_start_index": {
                     "description": "Start index for signal region in post-processing. NumPy style indexing.",
                     "format": "int32",
-                    "type": "integer"
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
                 },
                 "signal_stop_index": {
                     "description": "Stop index for signal region in post-processing. Numpy style indexing.",
                     "format": "int32",
-                    "type": "integer"
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
                 },
                 "use_baseline": {
                     "description": "Enable baseline subtraction for post-processing.",
-                    "type": "boolean"
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
                 }
             },
             "required": [
                 "range",
                 "coupling",
-                "impedance",
-                "filter",
-                "dc_offset",
-                "signal_start_index",
-                "signal_stop_index",
-                "use_baseline",
-                "invert"
+                "impedance"
             ],
             "title": "channel",
             "type": "object"

--- a/yaqd_gage/gage-chopping_config.json
+++ b/yaqd_gage/gage-chopping_config.json
@@ -14,9 +14,18 @@
                     "null"
                 ]
             },
+            "chop_channel": {
+                "default": 1,
+                "description": "Set which channel is the chop indicator.",
+                "format": "int32",
+                "type": [
+                    "integer",
+                    "null"
+                ]
+            },
             "depth": {
                 "default": 240,
-                "description": "Post-trigger depth, in samples.",
+                "description": "Post-trigger depth, in samples.  Numbers must be divisible by 16/[number of channels].",
                 "format": "int32",
                 "type": [
                     "integer",
@@ -82,11 +91,16 @@
                 ]
             },
             "mode": {
-                "default": 1073741828,
-                "description": "Sets the operating mode of the CompuScope system. Refer to the CompuScope documentation for valid values. Default is 1073741828 for FirmWare Averaging and four channels.",
-                "format": "int32",
+                "default": "quad",
+                "description": "Set how many channels will be active on board.",
+                "enum": [
+                    "quad",
+                    "dual",
+                    "single"
+                ],
+                "title": "acquisition_mode",
                 "type": [
-                    "integer",
+                    "string",
                     "null"
                 ]
             },
@@ -138,6 +152,15 @@
                     "null"
                 ]
             },
+            "signal_channel": {
+                "default": 0,
+                "description": "Set the signal channel. Defaults to 0.",
+                "format": "int32",
+                "type": [
+                    "integer",
+                    "null"
+                ]
+            },
             "time_stamp_clock": {
                 "default": "Fixed",
                 "description": "The time-stamping clock may operate in one of two modes. In fixed mode, the on-board oscillator will be used as the counter source. In sample mode, a frequency derived from the sampling clock will be used as the counter source.",
@@ -183,7 +206,7 @@
                 ]
             },
             "trigger_time_out": {
-                "default": 1000000,
+                "default": -1,
                 "description": "Trigger timeout of the CompuScope system. The value is in 100 nanosecond units of time (e.g. a value of 10,000,000 gives a trigger timeout of 1 second). A value of -1 will cause the driver to wait indefinitely for a trigger.",
                 "format": "int32",
                 "type": [
@@ -236,14 +259,6 @@
                     "format": "int32",
                     "type": "integer"
                 },
-                "diff_input": {
-                    "description": "Enable differential input coupling. Not all CompuScope models support differential input coupling.",
-                    "type": "boolean"
-                },
-                "direct_adc": {
-                    "description": "Enable direct-to-ADC input coupling. Not all CompuScope models support direct-to-ADC input coupling.",
-                    "type": "boolean"
-                },
                 "filter": {
                     "description": "Enable low-pass filtering. Not all CopuScope models support low-pass filtering.",
                     "type": "boolean"
@@ -284,8 +299,6 @@
                 "range",
                 "coupling",
                 "impedance",
-                "diff_input",
-                "direct_adc",
                 "filter",
                 "dc_offset",
                 "signal_start_index",
@@ -379,9 +392,18 @@
                         "null"
                     ]
                 },
+                "chop_channel": {
+                    "default": 1,
+                    "description": "Set which channel is the chop indicator.",
+                    "format": "int32",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
                 "depth": {
                     "default": 240,
-                    "description": "Post-trigger depth, in samples.",
+                    "description": "Post-trigger depth, in samples.  Numbers must be divisible by 16/[number of channels].",
                     "format": "int32",
                     "type": [
                         "integer",
@@ -447,11 +469,16 @@
                     ]
                 },
                 "mode": {
-                    "default": 1073741828,
-                    "description": "Sets the operating mode of the CompuScope system. Refer to the CompuScope documentation for valid values. Default is 1073741828 for FirmWare Averaging and four channels.",
-                    "format": "int32",
+                    "default": "quad",
+                    "description": "Set how many channels will be active on board.",
+                    "enum": [
+                        "quad",
+                        "dual",
+                        "single"
+                    ],
+                    "title": "acquisition_mode",
                     "type": [
-                        "integer",
+                        "string",
                         "null"
                     ]
                 },
@@ -503,6 +530,15 @@
                         "null"
                     ]
                 },
+                "signal_channel": {
+                    "default": 0,
+                    "description": "Set the signal channel. Defaults to 0.",
+                    "format": "int32",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
                 "time_stamp_clock": {
                     "default": "Fixed",
                     "description": "The time-stamping clock may operate in one of two modes. In fixed mode, the on-board oscillator will be used as the counter source. In sample mode, a frequency derived from the sampling clock will be used as the counter source.",
@@ -548,7 +584,7 @@
                     ]
                 },
                 "trigger_time_out": {
-                    "default": 1000000,
+                    "default": -1,
                     "description": "Trigger timeout of the CompuScope system. The value is in 100 nanosecond units of time (e.g. a value of 10,000,000 gives a trigger timeout of 1 second). A value of -1 will cause the driver to wait indefinitely for a trigger.",
                     "format": "int32",
                     "type": [

--- a/yaqd_gage/gage-compuscope.avpr
+++ b/yaqd_gage/gage-compuscope.avpr
@@ -165,6 +165,10 @@
             "request": [],
             "response": "boolean"
         },
+        "get_acq_config": {
+            "request": [],
+            "response": "string"
+        },
         "get_channel_names": {
             "doc": "Get current channel names.",
             "origin": "is-sensor",

--- a/yaqd_gage/gage-compuscope.avpr
+++ b/yaqd_gage/gage-compuscope.avpr
@@ -63,7 +63,7 @@
             ]
         },
         "mode": {
-            "default": 1073741828,
+            "default": "quad",
             "doc": "Sets the operating mode of the CompuScope system. Refer to the CompuScope documentation for valid values. Default is 1073741825 for FirmWare Averaging",
             "type": "int"
         },
@@ -352,6 +352,16 @@
     ],
     "types": [
         {
+            "default": "quad",
+            "name": "acquisition_mode",
+            "symbols": [
+                "quad",
+                "dual",
+                "single"
+            ],
+            "type": "enum"
+        },
+        {
             "default": "DC",
             "name": "coupling_mode",
             "symbols": [
@@ -361,11 +371,11 @@
             "type": "enum"
         },
         {
-            "default": "fifty",
+            "default": "low",
             "name": "impedance_mode",
             "symbols": [
-                "fifty",
-                "onemeg"
+                "low",
+                "high"
             ],
             "type": "enum"
         },

--- a/yaqd_gage/gage-compuscope.toml
+++ b/yaqd_gage/gage-compuscope.toml
@@ -17,6 +17,12 @@ PyPI = "https://pypi.org/project/yaqd-gage"
 
 [[types]]
 type = "enum"
+name = "acquisition_mode"
+symbols = ["quad", "dual", "single"]
+default = "quad"
+
+[[types]]
+type = "enum"
 name = "coupling_mode"
 symbols = ["AC", "DC"]
 default = "DC"
@@ -24,42 +30,46 @@ default = "DC"
 [[types]]
 type = "enum"
 name = "impedance_mode"
-symbols = ["fifty", "onemeg"]
-default = "fifty"
+symbols = ["low", "high"]
+default = "low"
 
 [[types]]
 type = "record"
 name = "channel"
-fields = [{"name"="range", "type"="int", "doc"="Full input range in millivolts."},
-          {"name"="coupling", "type"="coupling_mode"},
-	  {"name"="impedance", "type"="impedance_mode"},
-	  {"name"="diff_input", "type"="boolean", "default"=false, "doc"="Enable differential input coupling. Not all CompuScope models support differential input coupling."},
-	  {"name"="direct_adc", "type"="boolean", "default"=false, "doc"="Enable direct-to-ADC input coupling. Not all CompuScope models support direct-to-ADC input coupling."},
-	  {"name"="filter", "type"="boolean", "default"=false, "doc"="Enable low-pass filtering. Not all CopuScope models support low-pass filtering."},
-	  {"name"="dc_offset", "type"="int", "default"=0, "doc"="DC offset for this channel in millivolts. Can be negative or positive."},
-	  {"name"="signal_start_index", "type"="int", "default"=0, "doc"="Start index for signal region in post-processing. NumPy style indexing."},
-	  {"name"="signal_stop_index", "type"="int", "default"=-1, "doc"="Stop index for signal region in post-processing. Numpy style indexing."},
-	  {"name"="baseline_start_index", "type"=["null", "int"], "default"="__null__", "doc"="Start index for baseline region in post-processing. NumPy style indexing."},
-	  {"name"="baseline_stop_index", "type"=["null", "int"], "default"="__null__", "doc"="Stop index for baseline region in post-processing. Numpy style indexing."},
-	  {"name"="use_baseline", "type"="boolean", "default"=false, "doc"="Enable baseline subtraction for post-processing."},
-	  {"name"="invert", "type"="boolean", "default"=false, "doc"="If true, post-processed signal is inverted."}]
+fields = [
+	{"name"="range", "type"="int", "doc"="Full input range in millivolts."},
+	{"name"="coupling", "type"="coupling_mode"},
+	{"name"="impedance", "type"="impedance_mode"},
+	{"name"="diff_input", "type"="boolean", "default"=false, "doc"="Enable differential input coupling. Not all CompuScope models support differential input coupling."},
+	{"name"="direct_adc", "type"="boolean", "default"=false, "doc"="Enable direct-to-ADC input coupling. Not all CompuScope models support direct-to-ADC input coupling."},
+	{"name"="filter", "type"="boolean", "default"=false, "doc"="Enable low-pass filtering. Not all CopuScope models support low-pass filtering."},
+	{"name"="dc_offset", "type"="int", "default"=0, "doc"="DC offset for this channel in millivolts. Can be negative or positive."},
+	{"name"="signal_start_index", "type"="int", "default"=0, "doc"="Start index for signal region in post-processing. NumPy style indexing."},
+	{"name"="signal_stop_index", "type"="int", "default"=-1, "doc"="Stop index for signal region in post-processing. Numpy style indexing."},
+	{"name"="baseline_start_index", "type"=["null", "int"], "default"="__null__", "doc"="Start index for baseline region in post-processing. NumPy style indexing."},
+	{"name"="baseline_stop_index", "type"=["null", "int"], "default"="__null__", "doc"="Stop index for baseline region in post-processing. Numpy style indexing."},
+	{"name"="use_baseline", "type"="boolean", "default"=false, "doc"="Enable baseline subtraction for post-processing."},
+	{"name"="invert", "type"="boolean", "default"=false, "doc"="If true, post-processed signal is inverted."}
+]
 
 [[types]]
 type = "record"
 name = "trigger"
-fields = [{"name"="range", "type"="int", "doc"="Full input range in millivolts."},
-          {"name"="condition", "type"="int", "doc"="Trigger condition. Refer to the CompuScope documentation for valid values."},
-          {"name"="level", "type"="float", "default"=0.0, "doc"="Trigger level as a perentage of the input range of the trigger source (half the full scale input range). For example, in the 2000 mV range at 0 DC offset, 50 would be positive 50% of 1 Volt, or 500 millivolts."},
-	  {"name"="source", "type"="int", "doc"="Trigger source. Refer to the CompuScope documentation for valid values."},
-	  {"name"="coupling", "type"="coupling_mode"},
-	  {"name"="impedance", "type"="impedance_mode"}]
+fields = [
+	{"name"="range", "type"="int", "doc"="Full input range in millivolts."},
+	{"name"="condition", "type"="int", "doc"="Trigger condition. Refer to the CompuScope documentation for valid values."},
+	{"name"="level", "type"="float", "default"=0.0, "doc"="Trigger level as a perentage of the input range of the trigger source (half the full scale input range). For example, in the 2000 mV range at 0 DC offset, 50 would be positive 50% of 1 Volt, or 500 millivolts."},
+	{"name"="source", "type"="int", "doc"="Trigger source. Refer to the CompuScope documentation for valid values."},
+	{"name"="coupling", "type"="coupling_mode"},
+	{"name"="impedance", "type"="impedance_mode"}
+]
 
 [config]
 
 [config.mode]
 doc = "Sets the operating mode of the CompuScope system. Refer to the CompuScope documentation for valid values. Default is 1073741825 for FirmWare Averaging"
 type = "int"
-default = 0x40000004
+default = "quad"
 
 [config.sample_rate]
 doc = "Sampling rate in Hertz. If not provided, model-dependent default is used."

--- a/yaqd_gage/gage-compuscope.toml
+++ b/yaqd_gage/gage-compuscope.toml
@@ -150,6 +150,9 @@ request = [{"name"="count", "type"="int"}]
 doc = "Get current segment count limits as defined by on-board memory."
 response = {"type"="array", "items"="int"}
 
+[messages.get_acq_config]
+response = "string"
+
 [properties]
 
 [properties.segment_count]

--- a/yaqd_gage/gage-compuscope_config.json
+++ b/yaqd_gage/gage-compuscope_config.json
@@ -82,7 +82,7 @@
                 ]
             },
             "mode": {
-                "default": 1073741828,
+                "default": "quad",
                 "description": "Sets the operating mode of the CompuScope system. Refer to the CompuScope documentation for valid values. Default is 1073741825 for FirmWare Averaging",
                 "format": "int32",
                 "type": [
@@ -249,8 +249,8 @@
                 },
                 "impedance": {
                     "enum": [
-                        "fifty",
-                        "onemeg"
+                        "low",
+                        "high"
                     ],
                     "title": "impedance_mode",
                     "type": "string"
@@ -312,8 +312,8 @@
                 },
                 "impedance": {
                     "enum": [
-                        "fifty",
-                        "onemeg"
+                        "low",
+                        "high"
                     ],
                     "title": "impedance_mode",
                     "type": "string"
@@ -428,7 +428,7 @@
                     ]
                 },
                 "mode": {
-                    "default": 1073741828,
+                    "default": "quad",
                     "description": "Sets the operating mode of the CompuScope system. Refer to the CompuScope documentation for valid values. Default is 1073741825 for FirmWare Averaging",
                     "format": "int32",
                     "type": [


### PR DESCRIPTION
greatly reduce overhead of data transfer by calling only once (instead of individual transfers for each segment).  This is done by changing depth and segment count values after measurement make the gage board it holds a single segment dataset.

Note on gage-chopping: with xpert signal averaging firmware loaded, single data transfer is limited to a size of 2**14 data points (e.g. 256 segments of depth 64).  I am not sure why this is a limit, but it is.  We could work in chunks to alleviate some of the overhead, but this fix largely dispenses of the need for xpert firmware, so we will revert to the default firmware and remove record counts as an option.  

As a result of grabbing all segments at once, it seems this also reduces the transfer time when the yaqc-qtpy gage plugin is running, because new segments are not rapidly recorded (only one segment shared per acquisition).

## data transfer improvement

Using the minimal segment size of 32, and only grabbing two channels:

* For each segment transferred x, the new transfer time follows `t= mx+b`, with `b~10 ms`, `m=400 ns / segment`.  The math processing in gage-chopping add another ~1 us / segment.  Before this PR, when each segment was transferred individually and all channels were grabbed, transfer took 0.5 ms per segment, so the transfer time was `t = mx`, with `m~0.5 ms / sample`.  In other words, the old method was faster only for segment counts >~20.
* the segment count time contribution matches the overhead time interval at  `x~2.5e4` segments; so thousands of segments come at basically no cost to the execution time.
* we have ~2 Gigasamples of memory, so with in quad mode and with segment size of 32, we can acquire ~15 million segments per channel in one acquisition.  At 100 kHz, this would correspond to a ~150 second acquisition.
* a 1 second acquisition at 100 kHz takes approximately 1.17 (~85% duty cycle).  previously would have taken ~50 seconds (~2% duty cycle)

## changes
* removing special utilities related to xpert signal averaging firmware (i.e. record counts)
* `gage-chopping` instead of assuming channel roles, config now sets a "chopping" channel and a list of "signal" channels to be processed across the chopped phases.   
* refactor `gage-compuscope` and `gage-chopping` to reduce redundancy (using a new parent class `GaGeSynchronous`)
* add config schema file (for experimental purposes)
* resolves #48 
* resolves #44
* addresses #51
